### PR TITLE
Add --include flag for multi-repo agent sessions

### DIFF
--- a/.hatchery/tasks/2026-04-22-multi-repo-support.md
+++ b/.hatchery/tasks/2026-04-22-multi-repo-support.md
@@ -1,0 +1,53 @@
+# Task: multi-repo-support
+
+**Status**: complete
+**Branch**: hatchery/multi-repo-support
+**Created**: 2026-04-22 16:09
+
+## Objective
+
+Users often need a single hatchery agent session with access to two or more repos simultaneously. The old workaround (create a parent dir, clone repos into it, run `hatchery new --no-worktree`) provided no branch isolation, no worktrees, and no lifecycle cleanup.
+
+## Context
+
+Add a first-class `--include <path>` flag to `hatchery new` that mounts additional directories inside the Docker container at `/includes/<basename>/`, with optional worktree isolation for git repos.
+
+## Summary
+
+### Key decisions
+
+**Mount strategy**: Secondary repos use a simple full rw bind-mount (`-v /host/path:/includes/<basename>:rw`). This naturally includes `.git/` so the agent can commit and changes are visible on the host — no layered git mount needed.
+
+**Worktree isolation**: When an included path is a git repo and worktrees are enabled (the default), `hatchery new` creates a `hatchery/<task-name>` worktree in that secondary repo, just like the primary. The worktree's `.git` pointer file is rewritten for container paths (same technique already used for the primary repo).
+
+**`.git` pointer rewrite**: Worktrees have a `.git` file pointing to `<repo>/.git/worktrees/<name>`, a host-absolute path that doesn't resolve inside the container. We write a corrected pointer to `session_dir/git_ptr_include_<basename>` and bind-mount it over the worktree's `.git` file.
+
+**docker.yaml `include:` section**: Config-file includes merged with CLI `--include` at `hatchery new` time (deduplicated by resolved absolute path).
+
+**Basename collision**: Two included paths sharing a basename get a numeric suffix: `/includes/api-1/`.
+
+**No-worktree mode**: `--include` works too — just a plain rw mount, no worktree created.
+
+**Non-git dirs**: Plain directories are just mounted rw; no worktree, no git pointer.
+
+**Lifecycle**: `"include": ["/abs/path/..."]` stored in task metadata. `resume` reconstructs mounts. `done` removes secondary worktrees. `delete` also deletes the secondary branches.
+
+### Files changed
+
+| File | Change |
+|------|--------|
+| `src/seekr_hatchery/tasks.py` | `CONTAINER_INCLUDES_ROOT = "/includes"`; `_include_container_basename()` helper; `sandbox_context()` extended with `include_paths` parameter |
+| `src/seekr_hatchery/git.py` | `create_include_worktrees()`, `remove_include_worktrees()`, `delete_include_branches()` helpers |
+| `src/seekr_hatchery/docker.py` | `include: list[str] = []` on `DockerConfig`; `_unique_basename()` helper; `docker_mounts_includes()`; `launch_docker()` and `launch_docker_no_worktree()` extended with `include_repos` |
+| `src/seekr_hatchery/resources/docker.yaml.template` | Commented `include:` section added |
+| `src/seekr_hatchery/cli.py` | `--include` option on `cmd_new`; `_resolve_include_repos()` helper; worktree creation/cleanup wired into new/resume/done/delete |
+| `tests/test_docker.py` | `TestDockerMountsIncludes`, `TestDockerConfigInclude` |
+| `tests/test_pure.py` | `TestSandboxContextIncludePaths` |
+| `tests/test_task_io.py` | `TestIncludeRoundTrip` |
+
+### Gotchas
+
+- **`test_no_worktree_skips_git_ptr` assertion**: The assertion `"git_ptr" in m` was too broad — pytest's `tmp_path` for a test named `test_no_worktree_skips_git_ptr` contains the literal string "git_ptr". Changed to check `session_dir / "git_ptr_include_repo-b"` explicitly.
+- **`DockerConfig` uses `extra="forbid"`**: The `include` field must be declared on the model; adding unknown fields at load time raises a Pydantic validation error.
+- **`_resolve_include_repos()` deduplicates by resolved absolute path**: CLI flags take precedence (listed first), config file entries are appended if not already present.
+- **`_launch_finalize()` in cli.py**: This function was not extended with `include_repos` because finalize mode doesn't need to reconstruct docker mounts — it reuses the already-running session.

--- a/src/seekr_hatchery/cli.py
+++ b/src/seekr_hatchery/cli.py
@@ -132,6 +132,40 @@ def _set_task_status(repo: Path, name: str, status: str) -> None:
     tasks.save_task(meta)
 
 
+def _resolve_include_repos(
+    cli_includes: tuple[Path, ...],
+    config_includes: list[str],
+    repo: Path,
+) -> list[Path]:
+    """Merge --include CLI paths with docker.yaml 'include:' entries.
+
+    CLI paths are always resolved against the current working directory (they
+    come from click.Path which handles that).  Config paths are resolved
+    relative to the primary repo root.  Duplicates (by resolved absolute path)
+    are removed while preserving order (CLI paths first).
+    """
+    seen: set[Path] = set()
+    result: list[Path] = []
+
+    for p in cli_includes:
+        resolved = p.resolve()
+        if resolved not in seen:
+            seen.add(resolved)
+            result.append(resolved)
+
+    for s in config_includes:
+        raw = Path(s)
+        resolved = (repo / raw).resolve() if not raw.is_absolute() else raw.resolve()
+        if not resolved.exists():
+            ui.warn(f"docker.yaml include path does not exist, skipping: {s}")
+            continue
+        if resolved not in seen:
+            seen.add(resolved)
+            result.append(resolved)
+
+    return result
+
+
 def _do_mark_done(name: str, repo: Path, worktree: Path) -> None:
     meta = tasks.load_task(repo, name)
     no_worktree = meta.get("no_worktree", False)
@@ -379,40 +413,6 @@ def _prompt_objective() -> str:
 def _session_env(name: str, repo: Path) -> dict[str, str]:
     """Env vars that identify the hatchery session to child processes (e.g. statusline scripts)."""
     return {**os.environ, "HATCHERY_TASK": name, "HATCHERY_REPO": str(repo)}
-
-
-def _resolve_include_repos(
-    cli_includes: tuple[Path, ...],
-    config_includes: list[str],
-    repo: Path,
-) -> list[Path]:
-    """Merge --include CLI paths with docker.yaml 'include:' entries.
-
-    CLI paths are always resolved against the current working directory (they
-    come from click.Path which handles that).  Config paths are resolved
-    relative to the primary repo root.  Duplicates (by resolved absolute path)
-    are removed while preserving order (CLI paths first).
-    """
-    seen: set[Path] = set()
-    result: list[Path] = []
-
-    for p in cli_includes:
-        resolved = p.resolve()
-        if resolved not in seen:
-            seen.add(resolved)
-            result.append(resolved)
-
-    for s in config_includes:
-        raw = Path(s)
-        resolved = (repo / raw).resolve() if not raw.is_absolute() else raw.resolve()
-        if not resolved.exists():
-            ui.warn(f"docker.yaml include path does not exist, skipping: {s}")
-            continue
-        if resolved not in seen:
-            seen.add(resolved)
-            result.append(resolved)
-
-    return result
 
 
 def _launch_new(

--- a/src/seekr_hatchery/cli.py
+++ b/src/seekr_hatchery/cli.py
@@ -135,6 +135,7 @@ def _set_task_status(repo: Path, name: str, status: str) -> None:
 def _do_mark_done(name: str, repo: Path, worktree: Path) -> None:
     meta = tasks.load_task(repo, name)
     no_worktree = meta.get("no_worktree", False)
+    include_repos = [Path(p) for p in meta.get("include", [])]
     no_commit = meta.get("no_commit", False)
 
     if not no_worktree:
@@ -157,6 +158,9 @@ def _do_mark_done(name: str, repo: Path, worktree: Path) -> None:
             ui.info(f"Worktree removed: {worktree}")
         else:
             ui.info(f"Worktree already gone: {worktree}")
+
+        if include_repos:
+            git.remove_include_worktrees(include_repos, name)
 
     meta["status"] = "complete"
     meta["completed"] = datetime.now().isoformat()
@@ -184,6 +188,7 @@ _WRAP_UP_PROMPT = (
 def _do_delete(name: str, repo: Path, worktree: Path, meta: dict, *, confirmed: bool = False) -> None:
     branch = meta["branch"]
     no_worktree = meta.get("no_worktree", False)
+    include_repos = [Path(p) for p in meta.get("include", [])]
 
     if not no_worktree:
         if worktree.exists():
@@ -205,6 +210,10 @@ def _do_delete(name: str, repo: Path, worktree: Path, meta: dict, *, confirmed: 
             ui.info(f"Branch deleted: {branch}")
         else:
             ui.info(f"Could not delete branch {branch} (may already be gone)")
+
+        if include_repos:
+            git.remove_include_worktrees(include_repos, name)
+            git.delete_include_branches(include_repos, name)
     else:
         if not confirmed:
             answer = input(f"Delete task '{name}' (metadata only)? [y/N] ").strip().lower()
@@ -356,6 +365,40 @@ def _session_env(name: str, repo: Path) -> dict[str, str]:
     return {**os.environ, "HATCHERY_TASK": name, "HATCHERY_REPO": str(repo)}
 
 
+def _resolve_include_repos(
+    cli_includes: tuple[Path, ...],
+    config_includes: list[str],
+    repo: Path,
+) -> list[Path]:
+    """Merge --include CLI paths with docker.yaml 'include:' entries.
+
+    CLI paths are always resolved against the current working directory (they
+    come from click.Path which handles that).  Config paths are resolved
+    relative to the primary repo root.  Duplicates (by resolved absolute path)
+    are removed while preserving order (CLI paths first).
+    """
+    seen: set[Path] = set()
+    result: list[Path] = []
+
+    for p in cli_includes:
+        resolved = p.resolve()
+        if resolved not in seen:
+            seen.add(resolved)
+            result.append(resolved)
+
+    for s in config_includes:
+        raw = Path(s)
+        resolved = (repo / raw).resolve() if not raw.is_absolute() else raw.resolve()
+        if not resolved.exists():
+            ui.warn(f"docker.yaml include path does not exist, skipping: {s}")
+            continue
+        if resolved not in seen:
+            seen.add(resolved)
+            result.append(resolved)
+
+    return result
+
+
 def _launch_new(
     repo: Path,
     worktree: Path,
@@ -368,7 +411,9 @@ def _launch_new(
     no_worktree: bool = False,
     is_chat: bool = False,
     no_cache: bool = False,
+    include_repos: list[Path] | None = None,
 ) -> None:
+    include_repos = include_repos or []
     session_dir = tasks.task_session_dir(repo, name)
     backend.on_new_task(session_dir)
     backend.on_before_launch(worktree)
@@ -376,7 +421,10 @@ def _launch_new(
         system_prompt = ""
         initial_prompt = ""
     else:
-        env_ctx = tasks.sandbox_context(name, branch, worktree, repo, main_branch, bool(runtime), no_worktree)
+        env_ctx = tasks.sandbox_context(
+            name, branch, worktree, repo, main_branch, bool(runtime), no_worktree,
+            include_paths=include_repos,
+        )
         system_prompt = tasks.SESSION_SYSTEM + "\n" + env_ctx
         initial_prompt = tasks.session_prompt(name, worktree)
     config, features, container_workdir = _docker_context(runtime, None if no_worktree else worktree, repo)
@@ -391,9 +439,15 @@ def _launch_new(
     try:
         if runtime:
             if no_worktree:
-                docker.launch_docker_no_worktree(worktree, name, backend, agent_cmd, config, runtime, no_cache=no_cache)
+                docker.launch_docker_no_worktree(
+                    worktree, name, backend, agent_cmd, config, runtime,
+                    no_cache=no_cache, include_repos=include_repos,
+                )
             else:
-                docker.launch_docker(repo, worktree, name, backend, agent_cmd, config, runtime, no_cache=no_cache)
+                docker.launch_docker(
+                    repo, worktree, name, backend, agent_cmd, config, runtime,
+                    no_cache=no_cache, include_repos=include_repos,
+                )
         else:
             os.chdir(worktree)
             subprocess.run(agent_cmd, env=_session_env(name, repo))
@@ -419,13 +473,18 @@ def _launch_resume(
     no_worktree: bool = False,
     is_chat: bool = False,
     no_cache: bool = False,
+    include_repos: list[Path] | None = None,
 ) -> None:
+    include_repos = include_repos or []
     backend.on_before_launch(worktree)
     if is_chat:
         system_prompt = ""
         initial_prompt = ""
     else:
-        env_ctx = tasks.sandbox_context(name, branch, worktree, repo, main_branch, bool(runtime), no_worktree)
+        env_ctx = tasks.sandbox_context(
+            name, branch, worktree, repo, main_branch, bool(runtime), no_worktree,
+            include_paths=include_repos,
+        )
         system_prompt = tasks.SESSION_SYSTEM + "\n" + env_ctx
         initial_prompt = tasks.session_prompt(name, worktree)
     config, features, container_workdir = _docker_context(runtime, None if no_worktree else worktree, repo)
@@ -440,9 +499,15 @@ def _launch_resume(
     try:
         if runtime:
             if no_worktree:
-                docker.launch_docker_no_worktree(worktree, name, backend, agent_cmd, config, runtime, no_cache=no_cache)
+                docker.launch_docker_no_worktree(
+                    worktree, name, backend, agent_cmd, config, runtime,
+                    no_cache=no_cache, include_repos=include_repos,
+                )
             else:
-                docker.launch_docker(repo, worktree, name, backend, agent_cmd, config, runtime, no_cache=no_cache)
+                docker.launch_docker(
+                    repo, worktree, name, backend, agent_cmd, config, runtime,
+                    no_cache=no_cache, include_repos=include_repos,
+                )
         else:
             os.chdir(worktree)
             subprocess.run(agent_cmd, env=_session_env(name, repo))
@@ -627,6 +692,18 @@ def cli(log_level: str, log_file: str | None) -> None:
     ),
 )
 @click.option(
+    "--include",
+    "include",
+    multiple=True,
+    type=click.Path(exists=True, file_okay=False, dir_okay=True, path_type=Path),
+    metavar="PATH",
+    help=(
+        "Mount an additional directory inside the container at /includes/<basename>/. "
+        "Git repos get a hatchery/<name> worktree for branch isolation. "
+        "Repeatable; merged with docker.yaml 'include:' list."
+    ),
+)
+@click.option(
     "--no-commit",
     "no_commit",
     is_flag=True,
@@ -645,6 +722,7 @@ def cmd_new(
     agent_name: str,
     rebuild_sandbox: bool,
     no_commit_docker: bool,
+    include: tuple[Path, ...],
     no_commit: bool,
 ) -> None:
     """Start a new task."""
@@ -662,6 +740,14 @@ def cmd_new(
     tasks.ensure_tasks_dir(repo)
     if in_repo:
         tasks.ensure_gitignore(repo)
+
+    # Resolve --include paths (CLI flags + docker.yaml 'include:' list).
+    # We do a quick load of docker.yaml from the repo root (not yet from the
+    # worktree) to pick up any existing include entries before the worktree is
+    # created. The worktree-based load inside _docker_context later is for
+    # mount/dind settings only.
+    _early_config = docker.load_docker_config(repo)
+    include_repos = _resolve_include_repos(include, _early_config.include, repo)
 
     name = tasks.to_name(name)
     db_path = tasks.task_db_path(repo, name)
@@ -683,6 +769,8 @@ def cmd_new(
         worktree = tasks.worktrees_dir(repo) / name
         ui.info(f"Creating task: {name}")
         git.create_worktree(repo, branch, worktree, base)
+        if include_repos:
+            git.create_include_worktrees(include_repos, name, base)
 
     try:
         if in_repo:
@@ -743,6 +831,7 @@ def cmd_new(
             "no_worktree": no_worktree,
             "no_commit": no_commit,
             "agent": backend.kind,
+            "include": [str(p) for p in include_repos],
         }
         tasks.save_task(meta)
 
@@ -759,11 +848,14 @@ def cmd_new(
             main_branch,
             no_worktree,
             no_cache=rebuild_sandbox,
+            include_repos=include_repos,
         )
     except KeyboardInterrupt:
         if not no_worktree:
             git.remove_worktree(repo, worktree)
             git.delete_branch(repo, branch)
+            if include_repos:
+                git.remove_include_worktrees(include_repos, name)
         ui.warn("Cancelled.")
         sys.exit(1)
 
@@ -888,6 +980,7 @@ def cmd_resume(name: str, no_docker: bool, rebuild_sandbox: bool) -> None:
         ui.note(f"task '{name}' was marked as running — a previous session may have exited unexpectedly.")
 
     is_chat = meta.get("type") == "chat"
+    include_repos = [Path(p) for p in meta.get("include", [])]
     runtime = docker.resolve_runtime(repo, worktree, no_docker, backend=backend)
     main_branch = git.get_default_branch(repo)
     _launch_resume(
@@ -902,6 +995,7 @@ def cmd_resume(name: str, no_docker: bool, rebuild_sandbox: bool) -> None:
         no_worktree,
         is_chat=is_chat,
         no_cache=rebuild_sandbox,
+        include_repos=include_repos,
     )
 
 

--- a/src/seekr_hatchery/cli.py
+++ b/src/seekr_hatchery/cli.py
@@ -255,8 +255,13 @@ def _launch_finalize(
     branch: str,
     main_branch: str,
     no_worktree: bool = False,
+    include_repos: list[Path] | None = None,
 ) -> None:
-    env_ctx = tasks.sandbox_context(name, branch, worktree, repo, main_branch, bool(runtime), no_worktree)
+    include_repos = include_repos or []
+    env_ctx = tasks.sandbox_context(
+        name, branch, worktree, repo, main_branch, bool(runtime), no_worktree,
+        include_paths=include_repos,
+    )
     system_prompt = tasks.SESSION_SYSTEM + "\n" + env_ctx
     config, features, container_workdir = _docker_context(runtime, None if no_worktree else worktree, repo)
     agent_cmd = backend.build_finalize_command(
@@ -267,9 +272,15 @@ def _launch_finalize(
     try:
         if runtime:
             if no_worktree:
-                docker.launch_docker_no_worktree(worktree, name, backend, agent_cmd, config, runtime)
+                docker.launch_docker_no_worktree(
+                    worktree, name, backend, agent_cmd, config, runtime,
+                    include_repos=include_repos,
+                )
             else:
-                docker.launch_docker(repo, worktree, name, backend, agent_cmd, config, runtime)
+                docker.launch_docker(
+                    repo, worktree, name, backend, agent_cmd, config, runtime,
+                    include_repos=include_repos,
+                )
         else:
             os.chdir(worktree)
             subprocess.run(agent_cmd, env=_session_env(name, repo))
@@ -321,7 +332,12 @@ def _post_exit_check(
         backend = agent.from_kind(meta.get("agent", "CODEX"))
         runtime = docker.resolve_runtime(repo, worktree, no_docker=not sandbox, backend=backend)
         main_branch = git.get_default_branch(repo)
-        _launch_finalize(repo, worktree, name, session_id, backend, runtime, meta["branch"], main_branch, no_worktree)
+        include_repos = [Path(p) for p in meta.get("include", [])]
+        _launch_finalize(
+            repo, worktree, name, session_id, backend, runtime,
+            meta["branch"], main_branch, no_worktree,
+            include_repos=include_repos,
+        )
     elif choice == "x":
         meta = tasks.load_task(repo, name)
         _do_delete(name, repo, worktree, meta)
@@ -856,6 +872,7 @@ def cmd_new(
             git.delete_branch(repo, branch)
             if include_repos:
                 git.remove_include_worktrees(include_repos, name)
+                git.delete_include_branches(include_repos, name)
         ui.warn("Cancelled.")
         sys.exit(1)
 

--- a/src/seekr_hatchery/docker.py
+++ b/src/seekr_hatchery/docker.py
@@ -529,14 +529,7 @@ def docker_mounts_no_worktree(
     )
 
 
-def _unique_basename(name: str, used: set[str]) -> str:
-    """Return *name* if unused, else *name*-1, *name*-2, … until unique."""
-    if name not in used:
-        return name
-    i = 1
-    while f"{name}-{i}" in used:
-        i += 1
-    return f"{name}-{i}"
+_unique_basename = tasks._unique_basename
 
 
 def docker_mounts_includes(

--- a/src/seekr_hatchery/docker.py
+++ b/src/seekr_hatchery/docker.py
@@ -425,6 +425,40 @@ def _construct_docker_mounts(config: DockerConfig) -> list[str]:
     return result
 
 
+def _git_worktree_mounts(repo: Path, name: str, container_root: str) -> list[str]:
+    """Return the layered -v flags for one repo + worktree pair (pre-worktree portion).
+
+    Produces the read-only repo root + targeted read-write .git sub-mounts that
+    protect the main branch while allowing the hatchery/<name> worktree's git
+    metadata to be modified.  The worktree directory itself and any git-pointer
+    shadow file are NOT included — callers append those afterwards (so sentinel
+    files can be inserted between the .git layers and the worktree mount if needed).
+
+    This function is intentionally repo-agnostic: pass ``tasks.CONTAINER_REPO_ROOT``
+    for the primary repo or ``/includes/<basename>`` for an included secondary repo.
+    """
+    git_dir = repo / ".git"
+    mounts = [
+        f"{repo}:{container_root}:ro",          # repo root ro; .git overridden below
+        f"{git_dir}:{container_root}/.git:rw",  # unlock .git/ root for lock files
+        f"{git_dir / 'objects'}:{container_root}/.git/objects:rw",
+    ]
+    # Mount the entire hatchery/ ref directory rw so git can create .lock sidecar
+    # files alongside the branch ref during commits.
+    hatchery_refs = git_dir / "refs" / "heads" / "hatchery"
+    if hatchery_refs.exists():
+        mounts.append(f"{hatchery_refs}:{container_root}/.git/refs/heads/hatchery:rw")
+    logs_dir = git_dir / "logs"
+    if logs_dir.exists():
+        mounts.append(f"{logs_dir}:{container_root}/.git/logs:rw")
+    # Only this task's worktree git metadata is writable; other worktrees' metadata
+    # is protected by the ro parent mount (prevents `git worktree prune` damage).
+    worktree_meta = git_dir / "worktrees" / name
+    if worktree_meta.exists():
+        mounts.append(f"{worktree_meta}:{container_root}/.git/worktrees/{name}:rw")
+    return mounts
+
+
 def docker_mounts(
     repo: Path,
     worktree: Path,
@@ -440,12 +474,12 @@ def docker_mounts(
       /repo                                       ← full repo + .git, read-only
       /repo/.git                                  ← read-write (allows lock files at .git/ root)
       /repo/.git/objects                          ← read-write (new commit objects)
-      /repo/.git/refs/heads/hatchery/                  ← read-write (own branch + lock sidecar files)
+      /repo/.git/refs/heads/hatchery/             ← read-write (own branch + lock sidecar files)
       /repo/.git/logs                             ← read-write (reflogs, if dir exists)
       /repo/.git/worktrees/<n>                    ← read-write (this task's index + HEAD only)
       /repo/.git/COMMIT_EDITMSG                   ← read-write (per-task sentinel file)
       /repo/.git/ORIG_HEAD                        ← read-write (per-task sentinel file)
-      /repo/.hatchery/worktrees/<n>                ← read-write (the ONLY place edits land)
+      /repo/.hatchery/worktrees/<n>               ← read-write (the ONLY place edits land)
       /repo/.hatchery/worktrees/<n>/.git          ← container-path-aware .git pointer (file)
       {CONTAINER_HOME}/...  ← agent-specific home mounts (see backend.home_mounts())
 
@@ -464,31 +498,10 @@ def docker_mounts(
         staging temp dir + post-exit copy-back, which means commits made inside the
         container are not visible via `git log` on the host until the session ends.
     """
-    git_dir = repo / ".git"
     worktree_rel = worktree.relative_to(repo)
     container_worktree = f"{tasks.CONTAINER_REPO_ROOT}/{worktree_rel}"
-    mounts = [
-        f"{repo}:{tasks.CONTAINER_REPO_ROOT}:ro",  # .git ro via parent; overridden below
-        f"{git_dir}:{tasks.CONTAINER_REPO_ROOT}/.git:rw",  # unlock .git/ root for lock files
-        f"{git_dir / 'objects'}:{tasks.CONTAINER_REPO_ROOT}/.git/objects:rw",
-    ]
 
-    # Mount the entire task/ ref directory rw so git can create .lock sidecar
-    # files alongside the branch ref during commits.  refs/heads/ itself is
-    # read-only via the parent repo mount, so main/develop/etc. stay protected.
-    hatchery_refs_dir = git_dir / "refs" / "heads" / "hatchery"
-    if hatchery_refs_dir.exists():
-        mounts.append(f"{hatchery_refs_dir}:{tasks.CONTAINER_REPO_ROOT}/.git/refs/heads/hatchery:rw")
-
-    logs_dir = git_dir / "logs"
-    if logs_dir.exists():
-        mounts.append(f"{logs_dir}:{tasks.CONTAINER_REPO_ROOT}/.git/logs:rw")
-
-    # Only this task's worktree git metadata is writable; other worktrees' metadata
-    # is protected by the ro parent mount (prevents `git worktree prune` damage).
-    worktree_meta = git_dir / "worktrees" / name
-    if worktree_meta.exists():
-        mounts.append(f"{worktree_meta}:{tasks.CONTAINER_REPO_ROOT}/.git/worktrees/{name}:rw")
+    mounts = _git_worktree_mounts(repo, name, tasks.CONTAINER_REPO_ROOT)
 
     # git writes these into .git/ root during normal commits; use per-task sentinel
     # files so .git/ root stays ro.
@@ -532,7 +545,7 @@ def docker_mounts_no_worktree(
 _unique_basename = tasks._unique_basename
 
 
-def docker_mounts_includes(
+def _docker_mounts_includes(
     include_paths: list[Path],
     name: str,
     session_dir: Path,
@@ -540,12 +553,15 @@ def docker_mounts_includes(
 ) -> list[str]:
     """Return -v flags for paths included via --include.
 
-    Each path is mounted read-write at /includes/<basename>/.  If two included
-    paths share a basename the second gets a numeric suffix (e.g. api-1).
+    Each path is mounted at /includes/<basename>/.  If two included paths share
+    a basename the second gets a numeric suffix (e.g. api-1).
 
-    For git repos that have a hatchery/<name> worktree, a corrected .git pointer
-    file is written to *session_dir* and bind-mounted over the worktree's .git
-    file so that git resolves the git-dir correctly inside the container.
+    For git repos with a hatchery/<name> worktree the same layered mount
+    strategy as the primary repo is applied (root:ro, targeted .git sub-dirs:rw,
+    worktree:rw) and a corrected .git pointer file is written to *session_dir*
+    and bind-mounted over the worktree's .git file.
+
+    Plain directories and no-worktree mode receive a simple rw mount.
     """
     mounts: list[str] = []
     used_basenames: set[str] = set()
@@ -555,17 +571,21 @@ def docker_mounts_includes(
         used_basenames.add(basename)
         container_path = f"{tasks.CONTAINER_INCLUDES_ROOT}/{basename}"
 
-        mounts.append(f"{path}:{container_path}:rw")
-
-        # For git repos with a worktree, rewrite the .git pointer to use
-        # the container-relative path (same technique as the primary worktree).
-        if not no_worktree and (path / ".git").exists():
+        is_git = (path / ".git").exists()
+        if not no_worktree and is_git:
             worktree = path / tasks.WORKTREES_SUBDIR / name
             if worktree.exists():
+                # Layered mounts: root ro + targeted .git rw (same as primary repo)
+                mounts.extend(_git_worktree_mounts(path, name, container_path))
                 container_worktree = f"{container_path}/.hatchery/worktrees/{name}"
+                mounts.append(f"{worktree}:{container_worktree}:rw")
+                # Rewrite .git pointer to use container-relative path
                 git_ptr_file = session_dir / f"git_ptr_include_{basename}"
                 git_ptr_file.write_text(f"gitdir: {container_path}/.git/worktrees/{name}\n")
                 mounts.append(f"{git_ptr_file}:{container_worktree}/.git:rw")
+                continue
+        # Plain directory or no-worktree: simple rw mount
+        mounts.append(f"{path}:{container_path}:rw")
 
     return mounts
 
@@ -881,7 +901,7 @@ def launch_docker(
     image = docker_image_name(repo, name)
     mounts = docker_mounts(repo, worktree, name, backend, session_dir, config, git_sentinels, worktree_git_ptr=git_ptr)
     if include_repos:
-        mounts.extend(docker_mounts_includes(include_repos, name, session_dir, no_worktree=False))
+        mounts.extend(_docker_mounts_includes(include_repos, name, session_dir, no_worktree=False))
     logger.debug(f"Launching {runtime.binary} container for task '{name}'")
     return _run_container(
         image,
@@ -938,7 +958,7 @@ def launch_docker_no_worktree(
     image = docker_image_name(cwd, name)
     mounts = docker_mounts_no_worktree(cwd, backend, session_dir, config=config)
     if include_repos:
-        mounts.extend(docker_mounts_includes(include_repos, name, session_dir, no_worktree=True))
+        mounts.extend(_docker_mounts_includes(include_repos, name, session_dir, no_worktree=True))
     logger.debug(f"Launching {runtime.binary} container for task '{name}' (no-worktree mode)")
     return _run_container(
         image,

--- a/src/seekr_hatchery/docker.py
+++ b/src/seekr_hatchery/docker.py
@@ -124,6 +124,7 @@ class DockerConfig(BaseModel):
     model_config = ConfigDict(extra="forbid")
     schema_version: Literal["1"] = "1"
     mounts: list[str] = []
+    include: list[str] = []
     dind: bool = False
     cap_add: list[str] = []
 
@@ -528,6 +529,54 @@ def docker_mounts_no_worktree(
     )
 
 
+def _unique_basename(name: str, used: set[str]) -> str:
+    """Return *name* if unused, else *name*-1, *name*-2, … until unique."""
+    if name not in used:
+        return name
+    i = 1
+    while f"{name}-{i}" in used:
+        i += 1
+    return f"{name}-{i}"
+
+
+def docker_mounts_includes(
+    include_paths: list[Path],
+    name: str,
+    session_dir: Path,
+    no_worktree: bool,
+) -> list[str]:
+    """Return -v flags for paths included via --include.
+
+    Each path is mounted read-write at /includes/<basename>/.  If two included
+    paths share a basename the second gets a numeric suffix (e.g. api-1).
+
+    For git repos that have a hatchery/<name> worktree, a corrected .git pointer
+    file is written to *session_dir* and bind-mounted over the worktree's .git
+    file so that git resolves the git-dir correctly inside the container.
+    """
+    mounts: list[str] = []
+    used_basenames: set[str] = set()
+
+    for path in include_paths:
+        basename = _unique_basename(path.name, used_basenames)
+        used_basenames.add(basename)
+        container_path = f"{tasks.CONTAINER_INCLUDES_ROOT}/{basename}"
+
+        mounts.append(f"{path}:{container_path}:rw")
+
+        # For git repos with a worktree, rewrite the .git pointer to use
+        # the container-relative path (same technique as the primary worktree).
+        if not no_worktree and (path / ".git").exists():
+            worktree = path / tasks.WORKTREES_SUBDIR / name
+            if worktree.exists():
+                container_worktree = f"{container_path}/.hatchery/worktrees/{name}"
+                git_ptr_file = session_dir / f"git_ptr_include_{basename}"
+                git_ptr_file.write_text(f"gitdir: {container_path}/.git/worktrees/{name}\n")
+                mounts.append(f"{git_ptr_file}:{container_worktree}/.git:rw")
+
+    return mounts
+
+
 def _default_home_mounts() -> list[str]:
     """Mounts applied to every container regardless of agent: .gitconfig and uv cache."""
     mounts: list[str] = []
@@ -787,6 +836,7 @@ def launch_docker(
     config: DockerConfig,
     runtime: Runtime = Runtime.DOCKER,
     no_cache: bool = False,
+    include_repos: list[Path] | None = None,
 ) -> None:
     """Replace the current process with a Docker-sandboxed agent session.
 
@@ -794,6 +844,10 @@ def launch_docker(
     Auth is provided via the appropriate API key env var or per-task config.
     *agent_cmd* must be the full command already built for Docker mode
     (``backend.build_*_command(docker=True, workdir=container_workdir)``).
+
+    *include_repos* — additional paths to mount at /includes/<basename>/ rw.
+    Git repos in this list that have a hatchery/<name> worktree will also have
+    their .git pointer corrected for the container environment.
     """
     try:
         mutator = backend.make_header_mutator()
@@ -833,6 +887,8 @@ def launch_docker(
     build_docker_image(repo, worktree, name, backend, runtime=runtime, no_cache=no_cache)
     image = docker_image_name(repo, name)
     mounts = docker_mounts(repo, worktree, name, backend, session_dir, config, git_sentinels, worktree_git_ptr=git_ptr)
+    if include_repos:
+        mounts.extend(docker_mounts_includes(include_repos, name, session_dir, no_worktree=False))
     logger.debug(f"Launching {runtime.binary} container for task '{name}'")
     return _run_container(
         image,
@@ -859,6 +915,7 @@ def launch_docker_no_worktree(
     config: DockerConfig,
     runtime: Runtime = Runtime.DOCKER,
     no_cache: bool = False,
+    include_repos: list[Path] | None = None,
 ) -> None:
     """Launch a Docker-sandboxed agent session with cwd mounted as /workspace.
 
@@ -866,6 +923,8 @@ def launch_docker_no_worktree(
     Builds the image from cwd/.hatchery/Dockerfile (same as standard mode).
     *agent_cmd* must be the full command already built for Docker mode
     (``backend.build_*_command(docker=True, workdir="/workspace")``).
+
+    *include_repos* — additional paths to mount at /includes/<basename>/ rw.
     """
     try:
         mutator = backend.make_header_mutator()
@@ -885,6 +944,8 @@ def launch_docker_no_worktree(
     build_docker_image(cwd, cwd, name, backend, runtime=runtime, no_cache=no_cache)
     image = docker_image_name(cwd, name)
     mounts = docker_mounts_no_worktree(cwd, backend, session_dir, config=config)
+    if include_repos:
+        mounts.extend(docker_mounts_includes(include_repos, name, session_dir, no_worktree=True))
     logger.debug(f"Launching {runtime.binary} container for task '{name}' (no-worktree mode)")
     return _run_container(
         image,

--- a/src/seekr_hatchery/git.py
+++ b/src/seekr_hatchery/git.py
@@ -113,6 +113,41 @@ def delete_branch(repo: Path, branch: str) -> bool:
     return result.returncode == 0
 
 
+def create_include_worktrees(includes: list[Path], name: str, base: str) -> None:
+    """Create a hatchery/<name> worktree inside each included path that is a git repo.
+
+    Non-git directories are silently skipped.
+    """
+    branch = f"hatchery/{name}"
+    for path in includes:
+        if (path / ".git").exists():
+            worktree = path / tasks.WORKTREES_SUBDIR / name
+            create_worktree(path, branch, worktree, base)
+            logger.debug("Include worktree created at %s", worktree)
+
+
+def remove_include_worktrees(includes: list[Path], name: str) -> None:
+    """Remove the hatchery/<name> worktree from each included git repo.
+
+    Non-git directories and missing worktrees are silently skipped.
+    """
+    for path in includes:
+        if (path / ".git").exists():
+            worktree = path / tasks.WORKTREES_SUBDIR / name
+            remove_worktree(path, worktree, force=True)
+
+
+def delete_include_branches(includes: list[Path], name: str) -> None:
+    """Delete the hatchery/<name> branch from each included git repo.
+
+    Non-git directories and missing branches are silently skipped.
+    """
+    branch = f"hatchery/{name}"
+    for path in includes:
+        if (path / ".git").exists():
+            delete_branch(path, branch)
+
+
 def get_default_branch(repo: Path) -> str:
     """Return the repo's default branch name (main / master / etc.)."""
     # Prefer the remote's HEAD pointer — reliable on repos with a remote.

--- a/src/seekr_hatchery/resources/docker.yaml.template
+++ b/src/seekr_hatchery/resources/docker.yaml.template
@@ -18,6 +18,15 @@ mounts:
   # DANGEROUS: Uncomment for ssh access
   # - "~/.ssh:/home/hatchery/.ssh:ro"
 
+# include: additional repos or directories to mount inside the container.
+# Each path is mounted read-write at /includes/<basename>/.
+# Git repos automatically get a hatchery/<task> worktree created for branch isolation.
+# Paths are relative to this repo's root, or absolute.
+# Merged with any --include flags passed to `hatchery new`.
+# include:
+#   - ../other-repo
+#   - /shared/data
+
 # Set to true to enable Podman-in-Podman (nested container support).
 # Also uncomment the DinD section in .hatchery/Dockerfile.
 dind: false

--- a/src/seekr_hatchery/tasks.py
+++ b/src/seekr_hatchery/tasks.py
@@ -92,18 +92,17 @@ Your workflow:
    This file will be merged into main as the permanent record of this task.
 """
 
-def _include_container_basename(path: Path, used: set[str]) -> str:
-    """Return a collision-safe container basename for an included path."""
-    name = path.name
+def _unique_basename(name: str, used: set[str]) -> str:
+    """Return *name* if not in *used*, else *name*-1, *name*-2, … — first unused variant.
+
+    Does NOT mutate *used*; callers are responsible for adding the result.
+    """
     if name not in used:
-        used.add(name)
         return name
     i = 1
     while f"{name}-{i}" in used:
         i += 1
-    result = f"{name}-{i}"
-    used.add(result)
-    return result
+    return f"{name}-{i}"
 
 
 def sandbox_context(
@@ -188,7 +187,8 @@ def sandbox_context(
         for inc in include_paths:
             is_git = (inc / ".git").exists()
             if use_docker:
-                basename = _include_container_basename(inc, used_basenames)
+                basename = _unique_basename(inc.name, used_basenames)
+                used_basenames.add(basename)
                 container_inc = f"{CONTAINER_INCLUDES_ROOT}/{basename}"
                 if is_git and not no_worktree:
                     container_inc_wt = f"{container_inc}/.hatchery/worktrees/{name}"

--- a/src/seekr_hatchery/tasks.py
+++ b/src/seekr_hatchery/tasks.py
@@ -58,6 +58,9 @@ DOCKER_CONFIG = Path(".hatchery") / "docker.yaml"
 # Inside the container the repo is always mounted here.
 CONTAINER_REPO_ROOT = "/repo"
 
+# Included paths (--include) are mounted under this prefix inside the container.
+CONTAINER_INCLUDES_ROOT = "/includes"
+
 # Appended to the agent's default system prompt (preserving its built-in
 # tool knowledge and workspace awareness). Edit here — single source of truth.
 SESSION_SYSTEM = """\
@@ -89,6 +92,20 @@ Your workflow:
    This file will be merged into main as the permanent record of this task.
 """
 
+def _include_container_basename(path: Path, used: set[str]) -> str:
+    """Return a collision-safe container basename for an included path."""
+    name = path.name
+    if name not in used:
+        used.add(name)
+        return name
+    i = 1
+    while f"{name}-{i}" in used:
+        i += 1
+    result = f"{name}-{i}"
+    used.add(result)
+    return result
+
+
 def sandbox_context(
     name: str,
     branch: str,
@@ -97,8 +114,10 @@ def sandbox_context(
     main_branch: str,
     use_docker: bool,
     no_worktree: bool = False,
+    include_paths: list[Path] | None = None,
 ) -> str:
     """Return a system-prompt section describing the sandbox environment."""
+    include_paths = include_paths or []
     if no_worktree and use_docker:
         lines = [
             "# Sandbox Environment",
@@ -162,6 +181,32 @@ def sandbox_context(
             "",
             f"When creating commits or pull requests, target `{main_branch}`. You may push to `{branch}` only.",
         ]
+
+    if include_paths:
+        lines += ["", "**Included paths** (read-write):"]
+        used_basenames: set[str] = set()
+        for inc in include_paths:
+            is_git = (inc / ".git").exists()
+            if use_docker:
+                basename = _include_container_basename(inc, used_basenames)
+                container_inc = f"{CONTAINER_INCLUDES_ROOT}/{basename}"
+                if is_git and not no_worktree:
+                    container_inc_wt = f"{container_inc}/.hatchery/worktrees/{name}"
+                    lines.append(
+                        f"- `{container_inc}/` — git repo; your worktree: `{container_inc_wt}/`"
+                    )
+                else:
+                    kind = "git repo" if is_git else "directory"
+                    lines.append(f"- `{container_inc}/` — {kind}")
+            else:
+                # Native mode: report host paths
+                if is_git and not no_worktree:
+                    wt = inc / WORKTREES_SUBDIR / name
+                    lines.append(f"- `{wt}/` — git repo worktree (host path)")
+                else:
+                    kind = "git repo" if is_git else "directory"
+                    lines.append(f"- `{inc}/` — {kind} (host path)")
+
     return "\n".join(lines)
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -16,6 +16,7 @@ from seekr_hatchery.cli import (
     _launch_new,
     _launch_resume,
     _next_chat_name,
+    _resolve_include_repos,
     cli,
 )
 
@@ -2289,3 +2290,471 @@ class TestSelfCompletions:
         runner = CliRunner()
         result = runner.invoke(cli, ["self", "completions"])
         assert result.exit_code == 1
+
+
+# ---------------------------------------------------------------------------
+# _resolve_include_repos
+# ---------------------------------------------------------------------------
+
+
+class TestResolveIncludeRepos:
+    def test_empty_both(self, tmp_path):
+        result = _resolve_include_repos((), [], tmp_path)
+        assert result == []
+
+    def test_cli_path_resolved(self, tmp_path):
+        p = tmp_path / "repo-b"
+        p.mkdir()
+        result = _resolve_include_repos((p,), [], tmp_path)
+        assert result == [p.resolve()]
+
+    def test_config_path_relative_to_repo(self, tmp_path):
+        repo_b = tmp_path / "repo-b"
+        repo_b.mkdir()
+        # config entry is relative to primary repo root (tmp_path)
+        result = _resolve_include_repos((), ["repo-b"], tmp_path)
+        assert result == [repo_b.resolve()]
+
+    def test_config_absolute_path(self, tmp_path):
+        repo_b = tmp_path / "repo-b"
+        repo_b.mkdir()
+        result = _resolve_include_repos((), [str(repo_b)], tmp_path)
+        assert result == [repo_b.resolve()]
+
+    def test_cli_takes_priority_deduplicates(self, tmp_path):
+        """CLI path and config path resolving to the same dir → only one entry."""
+        repo_b = tmp_path / "repo-b"
+        repo_b.mkdir()
+        result = _resolve_include_repos((repo_b,), ["repo-b"], tmp_path)
+        assert result == [repo_b.resolve()]
+
+    def test_order_cli_first(self, tmp_path):
+        """CLI entries come before config entries."""
+        a = tmp_path / "a"
+        b = tmp_path / "b"
+        a.mkdir()
+        b.mkdir()
+        result = _resolve_include_repos((a,), ["b"], tmp_path)
+        assert result == [a.resolve(), b.resolve()]
+
+    def test_missing_config_path_is_skipped(self, tmp_path, capsys):
+        """A config include path that doesn't exist is skipped with a warning."""
+        result = _resolve_include_repos((), ["nonexistent"], tmp_path)
+        assert result == []
+        captured = capsys.readouterr()
+        assert "nonexistent" in captured.err or "nonexistent" in captured.out
+
+
+# ---------------------------------------------------------------------------
+# cmd_new --include: metadata + worktree creation
+# ---------------------------------------------------------------------------
+
+
+class TestCliNewInclude:
+    def test_include_stored_in_metadata(self, tmp_path):
+        """--include paths are stored as absolute strings in saved metadata."""
+        runner = CliRunner()
+        repo_b = tmp_path / "repo-b"
+        repo_b.mkdir()
+
+        saved_meta = {}
+
+        with ExitStack() as stack:
+            mocks = [stack.enter_context(p) for p in _new_patches()]
+            (
+                mock_root, _, _, _, _,
+                mock_db_path, mock_wt_dir, mock_create_wt, _,
+                mock_write, _, mock_save, mock_docker, _, _,
+            ) = mocks
+            mock_root.return_value = (Path("/repo"), True)
+            mock_db_path.return_value = MagicMock(exists=lambda: False)
+            mock_wt_dir.return_value = Path("/repo/.hatchery/worktrees")
+            mock_write.return_value = Path("/repo/.hatchery/tasks/task.md")
+            mock_docker.return_value = None
+            mock_save.side_effect = saved_meta.update
+
+            stack.enter_context(patch("seekr_hatchery.cli.git.create_include_worktrees"))
+            stack.enter_context(patch("seekr_hatchery.cli.docker.load_docker_config",
+                                      return_value=MagicMock(include=[])))
+
+            result = runner.invoke(cli, ["new", "my-task", "--include", str(repo_b)])
+
+        assert result.exit_code == 0, result.output
+        assert str(repo_b.resolve()) in saved_meta.get("include", [])
+
+    def test_include_creates_secondary_worktrees(self, tmp_path):
+        """When --include points at a git repo, create_include_worktrees is called."""
+        runner = CliRunner()
+        repo_b = tmp_path / "repo-b"
+        repo_b.mkdir()
+        (repo_b / ".git").mkdir()
+
+        with ExitStack() as stack:
+            mocks = [stack.enter_context(p) for p in _new_patches()]
+            (
+                mock_root, _, _, _, _,
+                mock_db_path, mock_wt_dir, _, _,
+                mock_write, _, _, mock_docker, _, _,
+            ) = mocks
+            mock_root.return_value = (Path("/repo"), True)
+            mock_db_path.return_value = MagicMock(exists=lambda: False)
+            mock_wt_dir.return_value = Path("/repo/.hatchery/worktrees")
+            mock_write.return_value = Path("/repo/.hatchery/tasks/task.md")
+            mock_docker.return_value = None
+
+            mock_create_inc = stack.enter_context(
+                patch("seekr_hatchery.cli.git.create_include_worktrees")
+            )
+            stack.enter_context(patch("seekr_hatchery.cli.docker.load_docker_config",
+                                      return_value=MagicMock(include=[])))
+
+            runner.invoke(cli, ["new", "my-task", "--include", str(repo_b)])
+
+        mock_create_inc.assert_called_once()
+        call_includes = mock_create_inc.call_args[0][0]
+        assert any(repo_b.resolve() == p for p in call_includes)
+
+    def test_include_passed_to_launch_new(self, tmp_path):
+        """include_repos is forwarded to _launch_new."""
+        runner = CliRunner()
+        repo_b = tmp_path / "repo-b"
+        repo_b.mkdir()
+
+        with ExitStack() as stack:
+            mocks = [stack.enter_context(p) for p in _new_patches()]
+            (
+                mock_root, _, _, _, _,
+                mock_db_path, mock_wt_dir, _, _,
+                mock_write, _, _, mock_docker, mock_launch, _,
+            ) = mocks
+            mock_root.return_value = (Path("/repo"), True)
+            mock_db_path.return_value = MagicMock(exists=lambda: False)
+            mock_wt_dir.return_value = Path("/repo/.hatchery/worktrees")
+            mock_write.return_value = Path("/repo/.hatchery/tasks/task.md")
+            mock_docker.return_value = None
+
+            stack.enter_context(patch("seekr_hatchery.cli.git.create_include_worktrees"))
+            stack.enter_context(patch("seekr_hatchery.cli.docker.load_docker_config",
+                                      return_value=MagicMock(include=[])))
+
+            runner.invoke(cli, ["new", "my-task", "--include", str(repo_b)])
+
+        assert mock_launch.called
+        kwargs = mock_launch.call_args[1]
+        include_repos = kwargs.get("include_repos", [])
+        assert any(repo_b.resolve() == p for p in include_repos)
+
+    def test_keyboard_interrupt_removes_secondary_worktrees_and_branches(self, tmp_path):
+        """Ctrl-C during cmd_new removes include worktrees and deletes branches."""
+        runner = CliRunner()
+        repo_b = tmp_path / "repo-b"
+        repo_b.mkdir()
+
+        with ExitStack() as stack:
+            mocks = [stack.enter_context(p) for p in _new_patches()]
+            (
+                mock_root, _, _, _, _,
+                mock_db_path, mock_wt_dir, _, _,
+                mock_write, _, _, mock_docker, mock_launch, _,
+            ) = mocks
+            mock_root.return_value = (Path("/repo"), True)
+            mock_db_path.return_value = MagicMock(exists=lambda: False)
+            mock_wt_dir.return_value = Path("/repo/.hatchery/worktrees")
+            mock_write.return_value = Path("/repo/.hatchery/tasks/task.md")
+            mock_docker.return_value = None
+            mock_launch.side_effect = KeyboardInterrupt
+
+            mock_remove_inc = stack.enter_context(
+                patch("seekr_hatchery.cli.git.remove_include_worktrees")
+            )
+            mock_delete_inc = stack.enter_context(
+                patch("seekr_hatchery.cli.git.delete_include_branches")
+            )
+            stack.enter_context(patch("seekr_hatchery.cli.git.create_include_worktrees"))
+            stack.enter_context(patch("seekr_hatchery.cli.docker.load_docker_config",
+                                      return_value=MagicMock(include=[])))
+
+            result = runner.invoke(cli, ["new", "my-task", "--include", str(repo_b)])
+
+        assert result.exit_code == 1
+        mock_remove_inc.assert_called_once()
+        mock_delete_inc.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# cmd_resume — include_repos passed to _launch_resume
+# ---------------------------------------------------------------------------
+
+
+class TestCliResumeInclude:
+    def test_include_repos_passed_to_launch_resume(self, fake_tasks_db, tmp_path):
+        """include paths from metadata are forwarded to _launch_resume."""
+        runner = CliRunner()
+        repo_b = tmp_path / "repo-b"
+
+        with (
+            patch("seekr_hatchery.cli.tasks.load_task") as mock_load,
+            patch("seekr_hatchery.cli.docker.resolve_runtime", return_value=None),
+            patch("seekr_hatchery.cli.git.get_default_branch", return_value="main"),
+            patch("seekr_hatchery.cli._launch_resume") as mock_launch,
+            patch("seekr_hatchery.cli.Path") as mock_path_cls,
+        ):
+            worktree = MagicMock(spec=Path)
+            worktree.exists.return_value = True
+            mock_path_cls.return_value = worktree
+            mock_load.return_value = {
+                "name": "my-task",
+                "branch": "hatchery/my-task",
+                "worktree": "/some/worktree",
+                "repo": "/some/repo",
+                "session_id": "sid-123",
+                "include": [str(repo_b)],
+            }
+            runner.invoke(cli, ["resume", "my-task"])
+
+        assert mock_launch.called
+        kwargs = mock_launch.call_args[1]
+        include_repos = kwargs.get("include_repos", [])
+        # Path is globally mocked so each Path(p) returns the mock worktree object;
+        # verify that one include entry was constructed and forwarded.
+        assert len(include_repos) == 1
+
+    def test_missing_include_key_defaults_to_empty(self, fake_tasks_db):
+        """Tasks without 'include' metadata resume without error."""
+        runner = CliRunner()
+        with (
+            patch("seekr_hatchery.cli.tasks.load_task") as mock_load,
+            patch("seekr_hatchery.cli.docker.resolve_runtime", return_value=None),
+            patch("seekr_hatchery.cli.git.get_default_branch", return_value="main"),
+            patch("seekr_hatchery.cli._launch_resume") as mock_launch,
+            patch("seekr_hatchery.cli.Path") as mock_path_cls,
+        ):
+            worktree = MagicMock(spec=Path)
+            worktree.exists.return_value = True
+            mock_path_cls.return_value = worktree
+            mock_load.return_value = {
+                "name": "my-task",
+                "branch": "hatchery/my-task",
+                "worktree": "/some/worktree",
+                "repo": "/some/repo",
+                "session_id": "sid-123",
+            }
+            result = runner.invoke(cli, ["resume", "my-task"])
+
+        assert result.exit_code == 0
+        kwargs = mock_launch.call_args[1]
+        assert kwargs.get("include_repos", []) == []
+
+
+# ---------------------------------------------------------------------------
+# _do_mark_done / _do_delete — include cleanup
+# ---------------------------------------------------------------------------
+
+
+class TestDoMarkDoneInclude:
+    def test_done_removes_include_worktrees(self, fake_tasks_db):
+        """_do_mark_done calls remove_include_worktrees when include paths are present."""
+        repo = Path("/my/repo")
+        worktree = Path("/my/repo/.hatchery/worktrees/my-task")
+        repo_b = Path("/other/repo-b")
+
+        tasks.save_task({
+            "name": "my-task",
+            "branch": "hatchery/my-task",
+            "worktree": str(worktree),
+            "repo": str(repo),
+            "status": "in-progress",
+            "no_worktree": True,
+            "include": [str(repo_b)],
+        })
+
+        import seekr_hatchery.cli as cli_mod
+
+        with patch("seekr_hatchery.cli.git.remove_include_worktrees") as mock_remove:
+            cli_mod._do_mark_done("my-task", repo, worktree)
+
+        mock_remove.assert_not_called()  # no_worktree=True skips the whole block
+
+    def test_done_removes_include_worktrees_with_worktree_mode(self, fake_tasks_db, tmp_path):
+        """_do_mark_done with no_worktree=False removes include worktrees."""
+        repo = Path("/my/repo")
+        wt = tmp_path / "wt"
+        wt.mkdir()
+        repo_b = Path("/other/repo-b")
+
+        tasks.save_task({
+            "name": "my-task",
+            "branch": "hatchery/my-task",
+            "worktree": str(wt),
+            "repo": str(repo),
+            "status": "in-progress",
+            "no_worktree": False,
+            "include": [str(repo_b)],
+        })
+
+        import seekr_hatchery.cli as cli_mod
+
+        with (
+            patch("seekr_hatchery.cli.git.remove_worktree"),
+            patch("seekr_hatchery.cli.git.has_uncommitted_changes", return_value=False),
+            patch("seekr_hatchery.cli.git.remove_include_worktrees") as mock_remove,
+        ):
+            cli_mod._do_mark_done("my-task", repo, wt)
+
+        mock_remove.assert_called_once_with([repo_b], "my-task")
+
+    def test_done_no_include_does_not_call_remove(self, fake_tasks_db, tmp_path):
+        """_do_mark_done with no include paths does not call remove_include_worktrees."""
+        repo = Path("/my/repo")
+        wt = tmp_path / "wt"
+        wt.mkdir()
+
+        tasks.save_task({
+            "name": "my-task",
+            "branch": "hatchery/my-task",
+            "worktree": str(wt),
+            "repo": str(repo),
+            "status": "in-progress",
+            "no_worktree": False,
+        })
+
+        import seekr_hatchery.cli as cli_mod
+
+        with (
+            patch("seekr_hatchery.cli.git.remove_worktree"),
+            patch("seekr_hatchery.cli.git.has_uncommitted_changes", return_value=False),
+            patch("seekr_hatchery.cli.git.remove_include_worktrees") as mock_remove,
+        ):
+            cli_mod._do_mark_done("my-task", repo, wt)
+
+        mock_remove.assert_not_called()
+
+
+class TestDoDeleteInclude:
+    def test_delete_removes_worktrees_and_branches(self, fake_tasks_db, tmp_path):
+        """_do_delete calls remove_include_worktrees and delete_include_branches."""
+        repo = Path("/my/repo")
+        wt = tmp_path / "wt"
+        wt.mkdir()
+        repo_b = Path("/other/repo-b")
+
+        meta = {
+            "name": "my-task",
+            "branch": "hatchery/my-task",
+            "worktree": str(wt),
+            "repo": str(repo),
+            "status": "in-progress",
+            "no_worktree": False,
+            "include": [str(repo_b)],
+        }
+        tasks.save_task(meta)
+
+        import seekr_hatchery.cli as cli_mod
+
+        with (
+            patch("seekr_hatchery.cli.git.remove_worktree"),
+            patch("seekr_hatchery.cli.git.delete_branch", return_value=True),
+            patch("seekr_hatchery.cli.git.remove_include_worktrees") as mock_remove,
+            patch("seekr_hatchery.cli.git.delete_include_branches") as mock_delete_br,
+        ):
+            cli_mod._do_delete("my-task", repo, wt, meta, confirmed=True)
+
+        mock_remove.assert_called_once_with([repo_b], "my-task")
+        mock_delete_br.assert_called_once_with([repo_b], "my-task")
+
+    def test_delete_no_include_does_not_call_helpers(self, fake_tasks_db, tmp_path):
+        repo = Path("/my/repo")
+        wt = tmp_path / "wt"
+        wt.mkdir()
+
+        meta = {
+            "name": "my-task",
+            "branch": "hatchery/my-task",
+            "worktree": str(wt),
+            "repo": str(repo),
+            "status": "in-progress",
+            "no_worktree": False,
+        }
+        tasks.save_task(meta)
+
+        import seekr_hatchery.cli as cli_mod
+
+        with (
+            patch("seekr_hatchery.cli.git.remove_worktree"),
+            patch("seekr_hatchery.cli.git.delete_branch", return_value=True),
+            patch("seekr_hatchery.cli.git.remove_include_worktrees") as mock_remove,
+            patch("seekr_hatchery.cli.git.delete_include_branches") as mock_delete_br,
+        ):
+            cli_mod._do_delete("my-task", repo, wt, meta, confirmed=True)
+
+        mock_remove.assert_not_called()
+        mock_delete_br.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# _launch_finalize — include_repos
+# ---------------------------------------------------------------------------
+
+
+class TestLaunchFinalizeInclude:
+    def test_include_repos_passed_to_sandbox_context(self, tmp_path, spy_backend):
+        """_launch_finalize includes paths appear in the system prompt."""
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        (repo / ".git").mkdir()
+        worktree = tmp_path / "wt"
+        worktree.mkdir()
+        repo_b = tmp_path / "repo-b"
+        repo_b.mkdir()
+
+        with (
+            patch("seekr_hatchery.cli._set_task_status"),
+            patch("seekr_hatchery.cli._post_exit_check"),
+            patch("seekr_hatchery.cli.tasks.sandbox_context", wraps=tasks.sandbox_context) as mock_ctx,
+            patch("seekr_hatchery.cli._docker_context", return_value=(MagicMock(), [], "/workspace")),
+            patch("seekr_hatchery.cli.os.chdir"),
+            patch("seekr_hatchery.cli.subprocess.run"),
+        ):
+            _launch_finalize(
+                repo, worktree, "my-task", "sid-1", spy_backend,
+                runtime=None,  # no docker → uses subprocess path
+                branch="hatchery/my-task",
+                main_branch="main",
+                no_worktree=True,
+                include_repos=[repo_b],
+            )
+
+        # sandbox_context was called with include_paths=[repo_b]
+        assert mock_ctx.called
+        kwargs = mock_ctx.call_args[1]
+        assert repo_b in kwargs.get("include_paths", [])
+
+    def test_include_repos_forwarded_to_launch_docker(self, tmp_path, spy_backend):
+        """_launch_finalize forwards include_repos to launch_docker."""
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        (repo / ".git").mkdir()
+        worktree = tmp_path / "wt"
+        worktree.mkdir()
+        repo_b = tmp_path / "repo-b"
+        repo_b.mkdir()
+
+        with (
+            patch("seekr_hatchery.cli._set_task_status"),
+            patch("seekr_hatchery.cli._post_exit_check"),
+            patch("seekr_hatchery.cli.docker.launch_docker") as mock_launch,
+            patch("seekr_hatchery.cli._docker_context",
+                  return_value=(MagicMock(), [], "/repo/.hatchery/worktrees/my-task")),
+        ):
+            _launch_finalize(
+                repo, worktree, "my-task", "sid-1", spy_backend,
+                runtime=MagicMock(),
+                branch="hatchery/my-task",
+                main_branch="main",
+                no_worktree=False,
+                include_repos=[repo_b],
+            )
+
+        assert mock_launch.called
+        kwargs = mock_launch.call_args[1]
+        assert repo_b in kwargs.get("include_repos", [])

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2344,6 +2344,19 @@ class TestResolveIncludeRepos:
         captured = capsys.readouterr()
         assert "nonexistent" in captured.err or "nonexistent" in captured.out
 
+    def test_config_path_missing_on_another_machine(self, tmp_path, capsys):
+        """docker.yaml include path absent on current machine is skipped gracefully.
+
+        Scenario: a developer commits docker.yaml with 'include: [../repo-a]', but a
+        colleague pulls the repo and does not have repo-a checked out locally.
+        The path does not exist → warn and skip (no crash or hard error).
+        """
+        result = _resolve_include_repos((), ["../repo-a"], tmp_path)
+        assert result == []
+        captured = capsys.readouterr()
+        combined = captured.out + captured.err
+        assert "repo-a" in combined
+
 
 # ---------------------------------------------------------------------------
 # cmd_new --include: metadata + worktree creation

--- a/tests/test_docker.py
+++ b/tests/test_docker.py
@@ -609,7 +609,7 @@ class TestStreamBuild:
 
 
 # ---------------------------------------------------------------------------
-# docker_mounts_includes()
+# _docker_mounts_includes()
 # ---------------------------------------------------------------------------
 
 
@@ -621,12 +621,12 @@ class TestDockerMountsIncludes:
         session_dir = tmp_path / "session"
         session_dir.mkdir()
 
-        mounts = docker.docker_mounts_includes([plain], "my-task", session_dir, no_worktree=False)
+        mounts = docker._docker_mounts_includes([plain], "my-task", session_dir, no_worktree=False)
 
         assert f"{plain}:/includes/shared-data:rw" in mounts
 
     def test_git_repo_without_worktree_gets_rw_mount(self, tmp_path):
-        """A git repo with no worktree for the task is mounted rw without a git_ptr entry."""
+        """A git repo with no worktree for the task falls back to a simple rw mount."""
         repo = tmp_path / "repo-b"
         repo.mkdir()
         (repo / ".git").mkdir()
@@ -634,34 +634,43 @@ class TestDockerMountsIncludes:
         session_dir = tmp_path / "session"
         session_dir.mkdir()
 
-        mounts = docker.docker_mounts_includes([repo], "my-task", session_dir, no_worktree=False)
+        mounts = docker._docker_mounts_includes([repo], "my-task", session_dir, no_worktree=False)
 
         assert f"{repo}:/includes/repo-b:rw" in mounts
         # No git_ptr mount since worktree doesn't exist
         assert not any("git_ptr" in m for m in mounts)
 
-    def test_git_repo_with_worktree_gets_git_ptr_mount(self, tmp_path):
-        """A git repo with a task worktree gets a corrected .git pointer mount."""
+    def test_git_repo_with_worktree_gets_layered_mounts(self, tmp_path):
+        """A git repo with a task worktree gets layered mounts (root:ro, .git:rw, worktree:rw)."""
         import seekr_hatchery.tasks as tasks_mod
 
         repo = tmp_path / "repo-b"
         repo.mkdir()
-        (repo / ".git").mkdir()
+        git_dir = repo / ".git"
+        git_dir.mkdir()
+        (git_dir / "objects").mkdir()
         worktree = repo / tasks_mod.WORKTREES_SUBDIR / "my-task"
         worktree.mkdir(parents=True)
         session_dir = tmp_path / "session"
         session_dir.mkdir()
 
-        mounts = docker.docker_mounts_includes([repo], "my-task", session_dir, no_worktree=False)
+        mounts = docker._docker_mounts_includes([repo], "my-task", session_dir, no_worktree=False)
 
-        # rw mount for the whole repo
-        assert f"{repo}:/includes/repo-b:rw" in mounts
-        # git_ptr file is created and mounted
+        # Root is read-only
+        assert f"{repo}:/includes/repo-b:ro" in mounts
+        # .git sub-dirs are rw
+        assert f"{git_dir}:/includes/repo-b/.git:rw" in mounts
+        assert f"{git_dir / 'objects'}:/includes/repo-b/.git/objects:rw" in mounts
+        # Worktree itself is rw
+        container_wt = "/includes/repo-b/.hatchery/worktrees/my-task"
+        assert f"{worktree}:{container_wt}:rw" in mounts
+        # git pointer file is written and mounted
         git_ptr_file = session_dir / "git_ptr_include_repo-b"
         assert git_ptr_file.exists()
         assert "gitdir: /includes/repo-b/.git/worktrees/my-task" in git_ptr_file.read_text()
-        container_wt = "/includes/repo-b/.hatchery/worktrees/my-task"
         assert f"{git_ptr_file}:{container_wt}/.git:rw" in mounts
+        # No single full rw mount for root
+        assert f"{repo}:/includes/repo-b:rw" not in mounts
 
     def test_basename_collision_gets_numeric_suffix(self, tmp_path):
         """Two paths sharing the same basename get distinct container paths."""
@@ -672,13 +681,13 @@ class TestDockerMountsIncludes:
         session_dir = tmp_path / "session"
         session_dir.mkdir()
 
-        mounts = docker.docker_mounts_includes([a, b], "task", session_dir, no_worktree=False)
+        mounts = docker._docker_mounts_includes([a, b], "task", session_dir, no_worktree=False)
 
         assert f"{a}:/includes/api:rw" in mounts
         assert f"{b}:/includes/api-1:rw" in mounts
 
-    def test_no_worktree_skips_git_ptr(self, tmp_path):
-        """In no-worktree mode, no .git pointer is written even for git repos."""
+    def test_no_worktree_skips_layered_mounts(self, tmp_path):
+        """In no-worktree mode, git repos get a simple rw mount (no layering, no git_ptr)."""
         repo = tmp_path / "repo-b"
         repo.mkdir()
         (repo / ".git").mkdir()
@@ -688,7 +697,7 @@ class TestDockerMountsIncludes:
         session_dir = tmp_path / "session"
         session_dir.mkdir()
 
-        mounts = docker.docker_mounts_includes([repo], "my-task", session_dir, no_worktree=True)
+        mounts = docker._docker_mounts_includes([repo], "my-task", session_dir, no_worktree=True)
 
         assert f"{repo}:/includes/repo-b:rw" in mounts
         # No git_ptr pointer file should be written or mounted in no-worktree mode
@@ -697,7 +706,7 @@ class TestDockerMountsIncludes:
         assert not any(str(git_ptr_file) in m for m in mounts)
 
     def test_empty_list_returns_empty(self, tmp_path):
-        mounts = docker.docker_mounts_includes([], "task", tmp_path, no_worktree=False)
+        mounts = docker._docker_mounts_includes([], "task", tmp_path, no_worktree=False)
         assert mounts == []
 
 

--- a/tests/test_docker.py
+++ b/tests/test_docker.py
@@ -606,3 +606,117 @@ class TestStreamBuild:
         monkeypatch.setattr(docker.subprocess, "run", _mock_run)
         docker._stream_build(["echo", "hello"], cwd=_sys.modules["pathlib"].Path("."))
         assert captured_kwargs[0].get("stdin") is subprocess.DEVNULL
+
+
+# ---------------------------------------------------------------------------
+# docker_mounts_includes()
+# ---------------------------------------------------------------------------
+
+
+class TestDockerMountsIncludes:
+    def test_plain_dir_gets_rw_mount(self, tmp_path):
+        """A plain (non-git) directory is mounted rw at /includes/<basename>/."""
+        plain = tmp_path / "shared-data"
+        plain.mkdir()
+        session_dir = tmp_path / "session"
+        session_dir.mkdir()
+
+        mounts = docker.docker_mounts_includes([plain], "my-task", session_dir, no_worktree=False)
+
+        assert f"{plain}:/includes/shared-data:rw" in mounts
+
+    def test_git_repo_without_worktree_gets_rw_mount(self, tmp_path):
+        """A git repo with no worktree for the task is mounted rw without a git_ptr entry."""
+        repo = tmp_path / "repo-b"
+        repo.mkdir()
+        (repo / ".git").mkdir()
+        # No worktree created
+        session_dir = tmp_path / "session"
+        session_dir.mkdir()
+
+        mounts = docker.docker_mounts_includes([repo], "my-task", session_dir, no_worktree=False)
+
+        assert f"{repo}:/includes/repo-b:rw" in mounts
+        # No git_ptr mount since worktree doesn't exist
+        assert not any("git_ptr" in m for m in mounts)
+
+    def test_git_repo_with_worktree_gets_git_ptr_mount(self, tmp_path):
+        """A git repo with a task worktree gets a corrected .git pointer mount."""
+        import seekr_hatchery.tasks as tasks_mod
+
+        repo = tmp_path / "repo-b"
+        repo.mkdir()
+        (repo / ".git").mkdir()
+        worktree = repo / tasks_mod.WORKTREES_SUBDIR / "my-task"
+        worktree.mkdir(parents=True)
+        session_dir = tmp_path / "session"
+        session_dir.mkdir()
+
+        mounts = docker.docker_mounts_includes([repo], "my-task", session_dir, no_worktree=False)
+
+        # rw mount for the whole repo
+        assert f"{repo}:/includes/repo-b:rw" in mounts
+        # git_ptr file is created and mounted
+        git_ptr_file = session_dir / "git_ptr_include_repo-b"
+        assert git_ptr_file.exists()
+        assert "gitdir: /includes/repo-b/.git/worktrees/my-task" in git_ptr_file.read_text()
+        container_wt = "/includes/repo-b/.hatchery/worktrees/my-task"
+        assert f"{git_ptr_file}:{container_wt}/.git:rw" in mounts
+
+    def test_basename_collision_gets_numeric_suffix(self, tmp_path):
+        """Two paths sharing the same basename get distinct container paths."""
+        a = tmp_path / "a" / "api"
+        b = tmp_path / "b" / "api"
+        a.mkdir(parents=True)
+        b.mkdir(parents=True)
+        session_dir = tmp_path / "session"
+        session_dir.mkdir()
+
+        mounts = docker.docker_mounts_includes([a, b], "task", session_dir, no_worktree=False)
+
+        assert f"{a}:/includes/api:rw" in mounts
+        assert f"{b}:/includes/api-1:rw" in mounts
+
+    def test_no_worktree_skips_git_ptr(self, tmp_path):
+        """In no-worktree mode, no .git pointer is written even for git repos."""
+        repo = tmp_path / "repo-b"
+        repo.mkdir()
+        (repo / ".git").mkdir()
+        import seekr_hatchery.tasks as tasks_mod
+        worktree = repo / tasks_mod.WORKTREES_SUBDIR / "my-task"
+        worktree.mkdir(parents=True)
+        session_dir = tmp_path / "session"
+        session_dir.mkdir()
+
+        mounts = docker.docker_mounts_includes([repo], "my-task", session_dir, no_worktree=True)
+
+        assert f"{repo}:/includes/repo-b:rw" in mounts
+        # No git_ptr pointer file should be written or mounted in no-worktree mode
+        git_ptr_file = session_dir / "git_ptr_include_repo-b"
+        assert not git_ptr_file.exists()
+        assert not any(str(git_ptr_file) in m for m in mounts)
+
+    def test_empty_list_returns_empty(self, tmp_path):
+        mounts = docker.docker_mounts_includes([], "task", tmp_path, no_worktree=False)
+        assert mounts == []
+
+
+# ---------------------------------------------------------------------------
+# DockerConfig.include field
+# ---------------------------------------------------------------------------
+
+
+class TestDockerConfigInclude:
+    def test_defaults_to_empty(self):
+        config = docker.DockerConfig()
+        assert config.include == []
+
+    def test_parses_include_list(self):
+        config = docker.DockerConfig(include=["../repo-b", "/abs/path"])
+        assert config.include == ["../repo-b", "/abs/path"]
+
+    def test_extra_fields_still_forbidden(self):
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            docker.DockerConfig(unknown_field="oops")

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -100,3 +100,85 @@ class TestGitRootOrCwdWorktree:
 
         assert in_repo is True
         assert path == main_repo
+
+
+# ---------------------------------------------------------------------------
+# create_include_worktrees / remove_include_worktrees / delete_include_branches
+# ---------------------------------------------------------------------------
+
+
+class TestIncludeWorktreeHelpers:
+    """Tests for create/remove/delete_include_worktrees using mocked git calls."""
+
+    def _fake_run(self, returncode: int = 0):
+        return SimpleNamespace(returncode=returncode, stdout="", stderr="")
+
+    def test_create_skips_non_git_dir(self, tmp_path):
+        """A plain directory with no .git is silently skipped."""
+        plain = tmp_path / "plain"
+        plain.mkdir()
+        with patch("seekr_hatchery.git.create_worktree") as mock_cw:
+            git.create_include_worktrees([plain], "my-task", "HEAD")
+        mock_cw.assert_not_called()
+
+    def test_create_calls_create_worktree_for_git_repo(self, tmp_path):
+        """A directory with .git triggers create_worktree with the right args."""
+        repo_b = tmp_path / "repo-b"
+        repo_b.mkdir()
+        (repo_b / ".git").mkdir()
+        import seekr_hatchery.tasks as tasks_mod
+
+        with patch("seekr_hatchery.git.create_worktree") as mock_cw:
+            git.create_include_worktrees([repo_b], "my-task", "HEAD")
+
+        expected_worktree = repo_b / tasks_mod.WORKTREES_SUBDIR / "my-task"
+        mock_cw.assert_called_once_with(repo_b, "hatchery/my-task", expected_worktree, "HEAD")
+
+    def test_create_skips_non_git_passes_git(self, tmp_path):
+        """Mixed list: git repo gets a worktree, plain dir is skipped."""
+        repo_b = tmp_path / "repo-b"
+        repo_b.mkdir()
+        (repo_b / ".git").mkdir()
+        plain = tmp_path / "data"
+        plain.mkdir()
+
+        with patch("seekr_hatchery.git.create_worktree") as mock_cw:
+            git.create_include_worktrees([repo_b, plain], "t", "HEAD")
+
+        assert mock_cw.call_count == 1
+
+    def test_remove_skips_non_git_dir(self, tmp_path):
+        plain = tmp_path / "plain"
+        plain.mkdir()
+        with patch("seekr_hatchery.git.remove_worktree") as mock_rw:
+            git.remove_include_worktrees([plain], "my-task")
+        mock_rw.assert_not_called()
+
+    def test_remove_calls_remove_worktree_for_git_repo(self, tmp_path):
+        repo_b = tmp_path / "repo-b"
+        repo_b.mkdir()
+        (repo_b / ".git").mkdir()
+        import seekr_hatchery.tasks as tasks_mod
+
+        with patch("seekr_hatchery.git.remove_worktree") as mock_rw:
+            git.remove_include_worktrees([repo_b], "my-task")
+
+        expected_worktree = repo_b / tasks_mod.WORKTREES_SUBDIR / "my-task"
+        mock_rw.assert_called_once_with(repo_b, expected_worktree, force=True)
+
+    def test_delete_branches_skips_non_git_dir(self, tmp_path):
+        plain = tmp_path / "plain"
+        plain.mkdir()
+        with patch("seekr_hatchery.git.delete_branch") as mock_db:
+            git.delete_include_branches([plain], "my-task")
+        mock_db.assert_not_called()
+
+    def test_delete_branches_calls_delete_branch_for_git_repo(self, tmp_path):
+        repo_b = tmp_path / "repo-b"
+        repo_b.mkdir()
+        (repo_b / ".git").mkdir()
+
+        with patch("seekr_hatchery.git.delete_branch") as mock_db:
+            git.delete_include_branches([repo_b], "my-task")
+
+        mock_db.assert_called_once_with(repo_b, "hatchery/my-task")

--- a/tests/test_pure.py
+++ b/tests/test_pure.py
@@ -872,6 +872,86 @@ class TestTaskContainerName:
 # ---------------------------------------------------------------------------
 
 
+# ---------------------------------------------------------------------------
+# sandbox_context — include_paths
+# ---------------------------------------------------------------------------
+
+
+class TestSandboxContextIncludePaths:
+    """Verify that include_paths appear in the sandbox context output."""
+
+    _BASE = dict(
+        name="my-task",
+        branch="hatchery/my-task",
+        worktree=Path("/repo/.hatchery/worktrees/my-task"),
+        repo=Path("/repo"),
+        main_branch="main",
+    )
+
+    def _ctx(self, use_docker: bool, no_worktree: bool, include_paths=None) -> str:
+        return tasks.sandbox_context(
+            **self._BASE,
+            use_docker=use_docker,
+            no_worktree=no_worktree,
+            include_paths=include_paths,
+        )
+
+    def test_no_includes_produces_no_includes_section(self):
+        result = self._ctx(use_docker=True, no_worktree=False)
+        assert "Included paths" not in result
+
+    def test_empty_list_produces_no_includes_section(self):
+        result = self._ctx(use_docker=True, no_worktree=False, include_paths=[])
+        assert "Included paths" not in result
+
+    def test_docker_plain_dir_shows_container_path(self, tmp_path):
+        plain = tmp_path / "shared-data"
+        plain.mkdir()
+        result = self._ctx(use_docker=True, no_worktree=False, include_paths=[plain])
+        assert "Included paths" in result
+        assert "/includes/shared-data/" in result
+
+    def test_docker_git_repo_with_worktree_shows_worktree_path(self, tmp_path):
+        repo_b = tmp_path / "repo-b"
+        repo_b.mkdir()
+        (repo_b / ".git").mkdir()
+        import seekr_hatchery.tasks as tasks_mod
+        wt = repo_b / tasks_mod.WORKTREES_SUBDIR / "my-task"
+        wt.mkdir(parents=True)
+        result = self._ctx(use_docker=True, no_worktree=False, include_paths=[repo_b])
+        assert "/includes/repo-b/" in result
+        assert ".hatchery/worktrees/my-task" in result
+
+    def test_docker_basename_collision_shows_suffix(self, tmp_path):
+        a = tmp_path / "a" / "api"
+        b = tmp_path / "b" / "api"
+        a.mkdir(parents=True)
+        b.mkdir(parents=True)
+        result = self._ctx(use_docker=True, no_worktree=False, include_paths=[a, b])
+        assert "/includes/api/" in result
+        assert "/includes/api-1/" in result
+
+    def test_native_plain_dir_shows_host_path(self, tmp_path):
+        plain = tmp_path / "shared-data"
+        plain.mkdir()
+        result = self._ctx(use_docker=False, no_worktree=False, include_paths=[plain])
+        assert "Included paths" in result
+        assert str(plain) in result
+
+    def test_native_git_repo_shows_worktree_host_path(self, tmp_path):
+        repo_b = tmp_path / "repo-b"
+        repo_b.mkdir()
+        (repo_b / ".git").mkdir()
+        import seekr_hatchery.tasks as tasks_mod
+        wt = repo_b / tasks_mod.WORKTREES_SUBDIR / "my-task"
+        wt.mkdir(parents=True)
+        result = self._ctx(use_docker=False, no_worktree=False, include_paths=[repo_b])
+        assert str(wt) in result
+
+
+# ---------------------------------------------------------------------------
+
+
 class TestExecTaskShell:
     """Verify exec_task_shell execs directly into the named container."""
 

--- a/tests/test_task_io.py
+++ b/tests/test_task_io.py
@@ -281,6 +281,39 @@ class TestMigrateDb:
 # ---------------------------------------------------------------------------
 
 
+# ---------------------------------------------------------------------------
+# include field round-trip
+# ---------------------------------------------------------------------------
+
+
+class TestIncludeRoundTrip:
+    def test_include_field_persists(self, fake_tasks_db):
+        """The 'include' list round-trips through save_task / load_task."""
+        meta = {
+            "name": "my-task",
+            "repo": str(_REPO),
+            "status": "in-progress",
+            "include": ["/path/to/repo-b", "/shared/data"],
+        }
+        tasks.save_task(meta)
+        loaded = tasks.load_task(_REPO, "my-task")
+        assert loaded["include"] == ["/path/to/repo-b", "/shared/data"]
+
+    def test_missing_include_defaults_to_empty(self, fake_tasks_db):
+        """Older task metadata without 'include' loads without error."""
+        meta = {
+            "name": "my-task",
+            "repo": str(_REPO),
+            "status": "in-progress",
+        }
+        tasks.save_task(meta)
+        loaded = tasks.load_task(_REPO, "my-task")
+        assert loaded.get("include", []) == []
+
+
+# ---------------------------------------------------------------------------
+
+
 class TestSandboxContextChat:
     def test_no_worktree_docker_no_branch(self):
         """sandbox_context with no_worktree=True, branch='', use_docker=True


### PR DESCRIPTION
Adds `hatchery new --include <path>` (repeatable) so a single agent session can read and commit across two or more repos simultaneously.

Behaviour:
- Each included path is mounted read-write at /includes/<basename>/
- If the path is a git repo and worktrees are enabled, a hatchery/<name> worktree is created in the secondary repo and its .git pointer is rewritten for container paths (same technique as the primary repo)
- Plain directories and --no-worktree mode get a simple rw mount only
- Basename collisions get a numeric suffix (/includes/api-1/)
- docker.yaml gains an `include:` list merged with CLI flags
- Metadata stores include paths; resume, done, and delete honour them