### PR TITLE
feat: Add pasting images into agent session (via hatchery img) 

### DIFF
--- a/.hatchery/tasks/2026-05-14-fix-img-paste.md
+++ b/.hatchery/tasks/2026-05-14-fix-img-paste.md
@@ -1,0 +1,42 @@
+# Task: fix-img-paste
+
+**Status**: complete
+**Branch**: hatchery/fix-img-paste
+**Created**: 2026-05-14 10:38
+
+## Objective
+
+Currently a user cannot paste in an image to the chat. This is likely because the interactive shell is within the sandbox and the agent cli does not properly handle this. 
+
+Implement a change in the interactive shell that allows for a user to paste in images to the agent's shell. If its not easy, provide some other way of quickly pasting in an image into the sandbox so the agent can see it
+
+## Summary
+
+**Root cause:** The Codex CLI REPL runs inside a Docker container over a PTY (`-it`). Clipboard data from the host does not cross the container boundary, so direct image paste is not feasible without invasive changes to the Codex binary.
+
+**Solution:** Added `hatchery img [TASK] [--file PATH]` — a host-side command that bridges the gap using the already-shared filesystem (the worktree is mounted read-write into the container).
+
+**How it works:**
+1. User copies an image to their system clipboard
+2. User runs `hatchery img` (auto-detects the task if only one is running) from a second terminal on the host
+3. The command reads the PNG from clipboard and writes it to `<worktree>/paste-<timestamp>.png`
+4. It prints the container-accessible path (e.g., `/repo/.hatchery/worktrees/fix-img-paste/paste-20260514-103845.png`)
+5. User pastes that path into the agent REPL to reference the image
+
+**Platform support:**
+- macOS: `osascript` reads clipboard PNG data (no extra dependencies)
+- Linux Wayland: `wl-paste --type image/png`
+- Linux X11: `xclip -selection clipboard -t image/png -o`
+- `--file PATH`: bypass clipboard entirely (useful for CI or headless environments)
+
+**Key decisions:**
+- No new Python dependencies — stdlib + subprocess only
+- Auto-infer task when exactly one is in-progress; require name otherwise
+- Container path computed from `repo`-relative path + `CONTAINER_REPO_ROOT` prefix, which is always `/repo`; works for both worktree tasks and `--no-worktree` chat sessions
+
+**Files changed:**
+- `src/seekr_hatchery/cli.py`: added `_read_clipboard_image()`, `_resolve_img_task()`, and `cmd_img` command (~90 lines after `cmd_shell`)
+
+**Gotchas for future agents:**
+- The osascript snippet uses `«class PNGf»` (AppleScript chevron syntax). These are literal Unicode left/right double angle quotation marks (U+00AB / U+00BB), not `<<`/`>>`. Python source stores them as `\u00ab`/`\u00bb` escape sequences to avoid encoding issues.
+- The worktree is always at `<repo>/.hatchery/worktrees/<name>/` on the host and at `/repo/.hatchery/worktrees/<name>/` inside the container. The path computation uses `dest.relative_to(repo)` which handles this correctly for both task types.

--- a/src/seekr_hatchery/cli.py
+++ b/src/seekr_hatchery/cli.py
@@ -1425,7 +1425,7 @@ def _read_clipboard_image() -> bytes:
         try:
             script = (
                 f'set theFile to POSIX file "{tmp}"\n'
-                'set theData to the clipboard as \u00abclass PNGf\u00bb\n'
+                "set theData to the clipboard as \u00abclass PNGf\u00bb\n"
                 "set fileRef to open for access theFile with write permission\n"
                 "write theData to fileRef\n"
                 "close access fileRef"
@@ -1464,9 +1464,7 @@ def _resolve_img_task(repo: Path, name: str | None) -> dict:
     """Resolve task meta for the img command; auto-select if exactly one task is in-progress."""
     if name:
         return tasks.load_task(repo, name)
-    running = [
-        t for t in tasks.repo_tasks_for_current_repo(repo) if t.get("status") in ("in-progress", "running")
-    ]
+    running = [t for t in tasks.repo_tasks_for_current_repo(repo) if t.get("status") in ("in-progress", "running")]
     if len(running) == 1:
         return running[0]
     if not running:
@@ -1479,7 +1477,9 @@ def _resolve_img_task(repo: Path, name: str | None) -> dict:
 
 @cli.command("img")
 @click.argument("name", required=False, default=None, type=TASK_NAME)
-@click.option("--file", "file_path", type=click.Path(exists=True), default=None, help="Image file to use instead of clipboard")
+@click.option(
+    "--file", "file_path", type=click.Path(exists=True), default=None, help="Image file to use instead of clipboard"
+)
 def cmd_img(name: str | None, file_path: str | None) -> None:
     """Save a clipboard image to the task worktree so the agent can see it.
 

--- a/src/seekr_hatchery/cli.py
+++ b/src/seekr_hatchery/cli.py
@@ -1455,8 +1455,12 @@ def _read_clipboard_image() -> bytes:
             except FileNotFoundError:
                 continue
         raise RuntimeError(
-            "Could not read image from clipboard.\n"
-            "Install wl-clipboard (wl-paste) for Wayland or xclip for X11, then copy an image."
+            "Could not read image from clipboard (no Wayland/X11 display?).\n"
+            "Alternatives:\n"
+            "  hatchery img --file /path/to/image.png   # use a saved file\n"
+            "  cat image.png | hatchery img             # pipe from stdin\n"
+            "  maim | hatchery img                      # pipe a screenshot (Linux)\n"
+            "  screencapture -i - | hatchery img        # pipe a screenshot (macOS)"
         )
 
 
@@ -1480,44 +1484,42 @@ def _resolve_img_task(repo: Path, name: str | None) -> dict:
 @click.option(
     "--file", "file_path", type=click.Path(exists=True), default=None, help="Image file to use instead of clipboard"
 )
-def cmd_img(name: str | None, file_path: str | None) -> None:
-    """Save a clipboard image to the task worktree so the agent can see it.
+@click.option("--clipboard", "use_clipboard", is_flag=True, default=False, help="Read image from system clipboard")
+def cmd_img(name: str | None, file_path: str | None, use_clipboard: bool) -> None:
+    """Save an image to the task worktree so the agent can see it.
 
-    Reads an image from the system clipboard (or --file) and writes it into
-    the task's worktree as a timestamped PNG.  Prints the path to paste into
-    the agent chat — the path works both on the host and inside the container.
+    Image source priority: --file > --clipboard > stdin pipe > clipboard (default).
+    Prints the container path to paste into the agent chat.
     """
     repo, _ = git.git_root_or_cwd()
     meta = _resolve_img_task(repo, name)
     worktree = Path(meta["worktree"])
 
+    pastes_dir = worktree / tasks.PASTES_SUBDIR
+    pastes_dir.mkdir(parents=True, exist_ok=True)
+    timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+    dest = pastes_dir / f"paste-{timestamp}.png"
+
     if file_path:
-        data = Path(file_path).read_bytes()
+        dest.write_bytes(Path(file_path).read_bytes())
+    elif not (use_clipboard or sys.stdin.isatty()):
+        dest.write_bytes(sys.stdin.buffer.read())
     else:
         try:
-            data = _read_clipboard_image()
+            dest.write_bytes(_read_clipboard_image())
         except RuntimeError as e:
             ui.error(str(e))
             sys.exit(1)
 
-    timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
-    dest = worktree / f"paste-{timestamp}.png"
-    dest.write_bytes(data)
-
-    # Compute the path the agent sees inside the container.
-    # The repo is mounted at CONTAINER_REPO_ROOT, so the relative path from
-    # the repo root maps directly to the container path.
-    try:
-        rel = dest.relative_to(repo)
-        container_path = f"{tasks.CONTAINER_REPO_ROOT}/{rel}"
-    except ValueError:
-        # Worktree is outside the repo (shouldn't happen in normal usage).
-        container_path = str(dest)
-
     ui.success(f"Image saved: {dest}")
     click.echo()
     click.echo("Paste this path into the agent chat:")
-    click.echo(f"  {container_path}")
+    click.echo(f"  {dest}  (host / no-docker)")
+    try:
+        rel = dest.relative_to(repo)
+        click.echo(f"  {tasks.CONTAINER_REPO_ROOT}/{rel}  (inside container)")
+    except ValueError:
+        pass
 
 
 # ---------------------------------------------------------------------------

--- a/src/seekr_hatchery/cli.py
+++ b/src/seekr_hatchery/cli.py
@@ -1511,15 +1511,22 @@ def cmd_img(name: str | None, file_path: str | None, use_clipboard: bool) -> Non
             ui.error(str(e))
             sys.exit(1)
 
+    # Detect whether the task runs in Docker so we show the right path.
+    # resolve_runtime returns None when Docker is unavailable or unconfigured.
+    backend = agent.from_kind(meta.get("agent", "CODEX"))
+    runtime = docker.resolve_runtime(repo, worktree, no_docker=False, backend=backend)
+
     ui.success(f"Image saved: {dest}")
     click.echo()
     click.echo("Paste this path into the agent chat:")
-    click.echo(f"  {dest}  (host / no-docker)")
-    try:
-        rel = dest.relative_to(repo)
-        click.echo(f"  {tasks.CONTAINER_REPO_ROOT}/{rel}  (inside container)")
-    except ValueError:
-        pass
+    if runtime:
+        try:
+            rel = dest.relative_to(repo)
+            click.echo(f"  {tasks.CONTAINER_REPO_ROOT}/{rel}")
+        except ValueError:
+            click.echo(f"  {dest}")
+    else:
+        click.echo(f"  {dest}")
 
 
 # ---------------------------------------------------------------------------

--- a/src/seekr_hatchery/cli.py
+++ b/src/seekr_hatchery/cli.py
@@ -1414,6 +1414,112 @@ def cmd_shell(name: str) -> None:
     subprocess.run([shell], cwd=worktree)
 
 
+def _read_clipboard_image() -> bytes:
+    """Read PNG image bytes from the host clipboard. Raises RuntimeError on failure."""
+    import tempfile
+
+    if sys.platform == "darwin":
+        # macOS: osascript reads clipboard PNG data directly to a temp file.
+        with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as f:
+            tmp = f.name
+        try:
+            script = (
+                f'set theFile to POSIX file "{tmp}"\n'
+                'set theData to the clipboard as \u00abclass PNGf\u00bb\n'
+                "set fileRef to open for access theFile with write permission\n"
+                "write theData to fileRef\n"
+                "close access fileRef"
+            )
+            result = subprocess.run(["osascript", "-e", script], capture_output=True)
+            if result.returncode != 0:
+                raise RuntimeError(
+                    "Could not read image from clipboard. Copy an image first.\n"
+                    f"(osascript: {result.stderr.decode().strip()})"
+                )
+            data = open(tmp, "rb").read()
+            if not data:
+                raise RuntimeError("Clipboard does not contain an image. Copy an image first.")
+            return data
+        finally:
+            os.unlink(tmp)
+    else:
+        # Linux: try wl-paste (Wayland) then xclip (X11).
+        for cmd in (
+            ["wl-paste", "--type", "image/png"],
+            ["xclip", "-selection", "clipboard", "-t", "image/png", "-o"],
+        ):
+            try:
+                result = subprocess.run(cmd, capture_output=True)
+                if result.returncode == 0 and result.stdout:
+                    return result.stdout
+            except FileNotFoundError:
+                continue
+        raise RuntimeError(
+            "Could not read image from clipboard.\n"
+            "Install wl-clipboard (wl-paste) for Wayland or xclip for X11, then copy an image."
+        )
+
+
+def _resolve_img_task(repo: Path, name: str | None) -> dict:
+    """Resolve task meta for the img command; auto-select if exactly one task is in-progress."""
+    if name:
+        return tasks.load_task(repo, name)
+    running = [
+        t for t in tasks.repo_tasks_for_current_repo(repo) if t.get("status") in ("in-progress", "running")
+    ]
+    if len(running) == 1:
+        return running[0]
+    if not running:
+        ui.error("No in-progress tasks found. Specify a task name.")
+    else:
+        names = ", ".join(t["name"] for t in running)
+        ui.error(f"Multiple tasks in progress ({names}). Specify one: hatchery img <name>")
+    sys.exit(1)
+
+
+@cli.command("img")
+@click.argument("name", required=False, default=None, type=TASK_NAME)
+@click.option("--file", "file_path", type=click.Path(exists=True), default=None, help="Image file to use instead of clipboard")
+def cmd_img(name: str | None, file_path: str | None) -> None:
+    """Save a clipboard image to the task worktree so the agent can see it.
+
+    Reads an image from the system clipboard (or --file) and writes it into
+    the task's worktree as a timestamped PNG.  Prints the path to paste into
+    the agent chat — the path works both on the host and inside the container.
+    """
+    repo, _ = git.git_root_or_cwd()
+    meta = _resolve_img_task(repo, name)
+    worktree = Path(meta["worktree"])
+
+    if file_path:
+        data = Path(file_path).read_bytes()
+    else:
+        try:
+            data = _read_clipboard_image()
+        except RuntimeError as e:
+            ui.error(str(e))
+            sys.exit(1)
+
+    timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+    dest = worktree / f"paste-{timestamp}.png"
+    dest.write_bytes(data)
+
+    # Compute the path the agent sees inside the container.
+    # The repo is mounted at CONTAINER_REPO_ROOT, so the relative path from
+    # the repo root maps directly to the container path.
+    try:
+        rel = dest.relative_to(repo)
+        container_path = f"{tasks.CONTAINER_REPO_ROOT}/{rel}"
+    except ValueError:
+        # Worktree is outside the repo (shouldn't happen in normal usage).
+        container_path = str(dest)
+
+    ui.success(f"Image saved: {dest}")
+    click.echo()
+    click.echo("Paste this path into the agent chat:")
+    click.echo(f"  {container_path}")
+
+
 # ---------------------------------------------------------------------------
 # Config command group
 # ---------------------------------------------------------------------------

--- a/src/seekr_hatchery/tasks.py
+++ b/src/seekr_hatchery/tasks.py
@@ -54,6 +54,7 @@ SCHEMA_VERSION = 1
 DB_SCHEMA_VERSION = 1
 
 WORKTREES_SUBDIR = Path(".hatchery") / "worktrees"
+PASTES_SUBDIR = Path(".hatchery") / "pastes"
 DOCKER_CONFIG = Path(".hatchery") / "docker.yaml"
 
 # Inside the container the repo is always mounted here.
@@ -486,26 +487,28 @@ patterns, and gotchas before starting new work.
 
 
 def ensure_gitignore(repo: Path) -> None:
-    """Make sure .hatchery/worktrees/ is gitignored.
+    """Make sure .hatchery/worktrees/ and .hatchery/pastes/ are gitignored.
 
     Without this, git status in the main repo will show every file inside every
     worktree as untracked, which is very noisy.
     """
     gitignore = repo / ".gitignore"
-    entry = str(WORKTREES_SUBDIR) + "/"
+    entries = [str(WORKTREES_SUBDIR) + "/", str(PASTES_SUBDIR) + "/"]
 
+    existing_lines: list[str] = []
     if gitignore.exists():
-        lines = gitignore.read_text().splitlines()
-        if any(line.strip() == entry for line in lines):
-            logger.debug("gitignore entry '%s' already present", entry)
-            return  # already present
-        content = gitignore.read_text()
-        sep = "" if content.endswith("\n") else "\n"
-        gitignore.write_text(content + sep + entry + "\n")
-    else:
-        gitignore.write_text(entry + "\n")
+        existing_lines = gitignore.read_text().splitlines()
 
-    ui.info(f"  Added {entry} to .gitignore")
+    missing = [e for e in entries if not any(line.strip() == e for line in existing_lines)]
+    if not missing:
+        logger.debug("gitignore entries already present")
+        return
+
+    content = gitignore.read_text() if gitignore.exists() else ""
+    sep = "" if not content or content.endswith("\n") else "\n"
+    gitignore.write_text(content + sep + "\n".join(missing) + "\n")
+    for entry in missing:
+        ui.info(f"  Added {entry} to .gitignore")
 
 
 def open_for_editing(path: Path) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3411,7 +3411,7 @@ class TestCmdImg:
         # With no Docker the suggested path is the real host path, not /repo/...
         # It appears as an indented line after "Paste this path into the agent chat:"
         lines = result.output.splitlines()
-        chat_idx = next(i for i, l in enumerate(lines) if "Paste this path" in l)
+        chat_idx = next(i for i, line in enumerate(lines) if "Paste this path" in line)
         suggested = lines[chat_idx + 1].strip()
         assert suggested.startswith(str(repo))
         assert not suggested.startswith(tasks.CONTAINER_REPO_ROOT)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3348,7 +3348,10 @@ class TestCmdImg:
         tasks.save_task(meta)
 
     def _invoke(self, runner, repo, args, **kwargs):
-        with patch("seekr_hatchery.cli.git.git_root_or_cwd", return_value=(repo, True)):
+        with (
+            patch("seekr_hatchery.cli.git.git_root_or_cwd", return_value=(repo, True)),
+            patch("seekr_hatchery.cli.docker.resolve_runtime", return_value=None),
+        ):
             return runner.invoke(cli, args, **kwargs)
 
     def test_file_flag_saves_image_to_pastes_dir(self, tmp_path, fake_tasks_db):
@@ -3369,7 +3372,29 @@ class TestCmdImg:
         assert len(saved) == 1
         assert saved[0].read_bytes() == _FAKE_PNG
 
-    def test_file_flag_prints_both_paths(self, tmp_path, fake_tasks_db):
+    def test_prints_container_path_when_docker_available(self, tmp_path, fake_tasks_db):
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        worktree = repo / ".hatchery" / "worktrees" / "my-task"
+        worktree.mkdir(parents=True)
+        self._make_task(fake_tasks_db, repo, worktree)
+
+        src = tmp_path / "shot.png"
+        src.write_bytes(_FAKE_PNG)
+
+        runner = CliRunner()
+        with (
+            patch("seekr_hatchery.cli.git.git_root_or_cwd", return_value=(repo, True)),
+            patch("seekr_hatchery.cli.docker.resolve_runtime", return_value=MagicMock()),
+        ):
+            result = runner.invoke(cli, ["img", "my-task", "--file", str(src)])
+
+        assert result.exit_code == 0
+        # Container path starts with CONTAINER_REPO_ROOT, e.g. /repo/.hatchery/pastes/...
+        expected_prefix = tasks.CONTAINER_REPO_ROOT + "/"
+        assert any(line.strip().startswith(expected_prefix) for line in result.output.splitlines())
+
+    def test_prints_host_path_when_no_docker(self, tmp_path, fake_tasks_db):
         repo = tmp_path / "repo"
         repo.mkdir()
         worktree = repo / ".hatchery" / "worktrees" / "my-task"
@@ -3383,9 +3408,13 @@ class TestCmdImg:
         result = self._invoke(runner, repo, ["img", "my-task", "--file", str(src)])
 
         assert result.exit_code == 0
-        assert "(host / no-docker)" in result.output
-        assert "(inside container)" in result.output
-        assert tasks.CONTAINER_REPO_ROOT in result.output
+        # With no Docker the suggested path is the real host path, not /repo/...
+        # It appears as an indented line after "Paste this path into the agent chat:"
+        lines = result.output.splitlines()
+        chat_idx = next(i for i, l in enumerate(lines) if "Paste this path" in l)
+        suggested = lines[chat_idx + 1].strip()
+        assert suggested.startswith(str(repo))
+        assert not suggested.startswith(tasks.CONTAINER_REPO_ROOT)
 
     def test_clipboard_flag_calls_read_clipboard(self, tmp_path, fake_tasks_db):
         repo = tmp_path / "repo"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -60,6 +60,7 @@ class TestHelp:
             "delete",
             "done",
             "exec",
+            "img",
             "ls | list",
             "new",
             "resume",
@@ -3320,3 +3321,136 @@ class TestLaunchFinalizeInclude:
         assert mock_launch.called
         kwargs = mock_launch.call_args[1]
         assert entry_b in kwargs.get("include_repos", [])
+
+
+# ---------------------------------------------------------------------------
+# cmd_img()
+# ---------------------------------------------------------------------------
+
+_IMG_REPO = Path("/img/repo")
+_FAKE_PNG = b"\x89PNG\r\n\x1a\n" + b"\x00" * 16  # minimal PNG-like header
+
+
+class TestCmdImg:
+    """Tests for `hatchery img` — file load, clipboard, and stdin paths."""
+
+    def _make_task(self, fake_tasks_db: Path, repo: Path, worktree: Path) -> None:
+        meta = {
+            "name": "my-task",
+            "branch": "hatchery/my-task",
+            "worktree": str(worktree),
+            "repo": str(repo),
+            "status": "in-progress",
+            "created": "2026-01-15T10:00:00",
+            "session_id": "sid-img",
+            "schema_version": 1,
+        }
+        tasks.save_task(meta)
+
+    def _invoke(self, runner, repo, args, **kwargs):
+        with patch("seekr_hatchery.cli.git.git_root_or_cwd", return_value=(repo, True)):
+            return runner.invoke(cli, args, **kwargs)
+
+    def test_file_flag_saves_image_to_pastes_dir(self, tmp_path, fake_tasks_db):
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        worktree = repo / ".hatchery" / "worktrees" / "my-task"
+        worktree.mkdir(parents=True)
+        self._make_task(fake_tasks_db, repo, worktree)
+
+        src = tmp_path / "shot.png"
+        src.write_bytes(_FAKE_PNG)
+
+        runner = CliRunner()
+        result = self._invoke(runner, repo, ["img", "my-task", "--file", str(src)])
+
+        assert result.exit_code == 0
+        saved = list((worktree / tasks.PASTES_SUBDIR).glob("paste-*.png"))
+        assert len(saved) == 1
+        assert saved[0].read_bytes() == _FAKE_PNG
+
+    def test_file_flag_prints_both_paths(self, tmp_path, fake_tasks_db):
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        worktree = repo / ".hatchery" / "worktrees" / "my-task"
+        worktree.mkdir(parents=True)
+        self._make_task(fake_tasks_db, repo, worktree)
+
+        src = tmp_path / "shot.png"
+        src.write_bytes(_FAKE_PNG)
+
+        runner = CliRunner()
+        result = self._invoke(runner, repo, ["img", "my-task", "--file", str(src)])
+
+        assert result.exit_code == 0
+        assert "(host / no-docker)" in result.output
+        assert "(inside container)" in result.output
+        assert tasks.CONTAINER_REPO_ROOT in result.output
+
+    def test_clipboard_flag_calls_read_clipboard(self, tmp_path, fake_tasks_db):
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        worktree = repo / ".hatchery" / "worktrees" / "my-task"
+        worktree.mkdir(parents=True)
+        self._make_task(fake_tasks_db, repo, worktree)
+
+        runner = CliRunner()
+        with patch("seekr_hatchery.cli._read_clipboard_image", return_value=_FAKE_PNG) as mock_cb:
+            result = self._invoke(runner, repo, ["img", "my-task", "--clipboard"])
+
+        assert result.exit_code == 0
+        mock_cb.assert_called_once()
+        saved = list((worktree / tasks.PASTES_SUBDIR).glob("paste-*.png"))
+        assert len(saved) == 1
+        assert saved[0].read_bytes() == _FAKE_PNG
+
+    def test_clipboard_error_exits_nonzero(self, tmp_path, fake_tasks_db):
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        worktree = repo / ".hatchery" / "worktrees" / "my-task"
+        worktree.mkdir(parents=True)
+        self._make_task(fake_tasks_db, repo, worktree)
+
+        runner = CliRunner()
+        with patch(
+            "seekr_hatchery.cli._read_clipboard_image",
+            side_effect=RuntimeError("no display"),
+        ):
+            result = self._invoke(runner, repo, ["img", "my-task", "--clipboard"])
+
+        assert result.exit_code == 1
+        assert "no display" in result.output
+
+    def test_auto_selects_single_in_progress_task(self, tmp_path, fake_tasks_db):
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        worktree = repo / ".hatchery" / "worktrees" / "my-task"
+        worktree.mkdir(parents=True)
+        self._make_task(fake_tasks_db, repo, worktree)
+
+        src = tmp_path / "shot.png"
+        src.write_bytes(_FAKE_PNG)
+
+        runner = CliRunner()
+        # No task name supplied — should auto-detect the only in-progress task
+        result = self._invoke(runner, repo, ["img", "--file", str(src)])
+
+        assert result.exit_code == 0
+        saved = list((worktree / tasks.PASTES_SUBDIR).glob("paste-*.png"))
+        assert len(saved) == 1
+
+    def test_stdin_pipe_saves_image(self, tmp_path, fake_tasks_db):
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        worktree = repo / ".hatchery" / "worktrees" / "my-task"
+        worktree.mkdir(parents=True)
+        self._make_task(fake_tasks_db, repo, worktree)
+
+        runner = CliRunner()
+        # CliRunner with input= simulates piped stdin (non-TTY)
+        result = self._invoke(runner, repo, ["img", "my-task"], input=_FAKE_PNG)
+
+        assert result.exit_code == 0
+        saved = list((worktree / tasks.PASTES_SUBDIR).glob("paste-*.png"))
+        assert len(saved) == 1
+        assert saved[0].read_bytes() == _FAKE_PNG


### PR DESCRIPTION
new command `hatchery img` which lets you quickly move an image from clipboard or from filepath into an active container 

Couldn't get the fully paste functionality working but this is the next-best thing for now 