### PR TITLE
fix: Ensure proxy errors/warnings do not reach stdout

### DIFF
--- a/.hatchery/tasks/2026-08-05-fix-proxy-logging.md
+++ b/.hatchery/tasks/2026-08-05-fix-proxy-logging.md
@@ -1,0 +1,77 @@
+# Task: fix-proxy-logging
+
+**Status**: complete
+**Branch**: hatchery/fix-proxy-logging
+**Created**: 2026-08-05 15:30
+
+## Objective
+
+I get a visual bug every once in a while where the proxy logs like ssl errors are shown in the same chat as claude code. It resolves itself when I resize. Otherwise the text is completely manged. I will attach screenshots for you to see. You should investigate how the proxy logs, ensure they are being sent to the log file and not to stdout
+
+## Context
+
+Screenshots the user attached pinned the actual bug: repeated `urllib3`
+`InsecureRequestWarning` lines ("Unverified HTTPS request is being made to
+host 'api.anthropic.com'...") printed raw to stderr. This was **not** the
+`logger.*` calls in `proxy.py`/`kubectl_proxy.py`, which already went through
+`logging_.py` correctly — it was Python's `warnings` module, which writes
+straight to `sys.stderr` via `warnings.showwarning`, completely bypassing the
+logging pipeline.
+
+Root cause: `api_server()` in `proxy.py` builds its outbound
+`urllib3.PoolManager` with a `truststore.SSLContext`. `truststore`
+intentionally sets the underlying `ssl.SSLContext.verify_mode` to
+`CERT_NONE` (it does its own verification against the OS trust store
+post-handshake), so urllib3's `conn.is_verified` check concludes —
+incorrectly — that the connection is unverified and fires
+`InsecureRequestWarning` on every connection to `api.anthropic.com`. Since
+this proxy runs in a background thread of the host process while the
+container is attached to the same TTY (`subprocess.run([..., "exec", "-it",
+...])`), the raw stderr write corrupts the container's TUI until the next
+redraw (resize) — and it slipped past `detach_console_handler()`
+(`cli.py:219`), which exists specifically to prevent console output from
+corrupting the agent's TUI once the sandbox launches, because that function
+only ever touched the `seekr_hatchery` logger, not `warnings`.
+
+## Summary
+
+**Fix:**
+1. `src/seekr_hatchery/logging_.py` — added a `py.warnings` logger
+   (`_warnings_logger`) managed alongside `_pkg_logger` via a shared
+   `_MANAGED_LOGGERS` tuple. `configure_logging()` now attaches the same
+   console/file handlers to both and calls `logging.captureWarnings(True)`,
+   so `warnings.warn()` routes through the existing logging pipeline instead
+   of stderr. `detach_console_handler()` and `task_log()` were updated to
+   manage both loggers identically, so warnings behave exactly like any
+   other log line (visible pre-launch, silent + file-only after the agent
+   sandbox launches).
+2. `src/seekr_hatchery/proxy.py` and `src/seekr_hatchery/kubectl_proxy.py` —
+   overrode `handle_error()` on each `_ThreadingHTTPServer` subclass to log
+   via the module's `logger.warning(..., exc_info=True)` instead of
+   `socketserver.BaseServer`'s stdlib default, which also prints tracebacks
+   straight to stderr (e.g. on TLS handshake failures against the
+   TLS-terminating kubectl RBAC proxy). Same bug class, same fix shape,
+   fixed defensively even though the screenshots pointed at the `warnings`
+   path specifically.
+3. `tests/test_logging.py` — added `TestWarningsCapture` with two tests
+   (warnings reach the log file; warnings stay off stderr after
+   `detach_console_handler()`), plus a `clean_warnings_logger` fixture.
+
+**Gotcha for future agents:** `logging.captureWarnings()` has a
+process-global idempotency guard (`logging._warnings_showwarning`) — once
+set, later calls no-op. Meanwhile pytest wraps every test in its own
+`warnings.catch_warnings()`, which resets `warnings.showwarning` back to the
+stdlib default at each test's teardown. Combined, this meant that after the
+*first* test in a session called `configure_logging()`, every later test's
+call became a no-op and `warnings.warn()` silently fell back to raw stderr
+output — a pure test-ordering artifact, not a real bug (in production,
+`configure_logging()` runs exactly once per CLI invocation). The
+`clean_warnings_logger` fixture works around it by calling
+`logging.captureWarnings(False)` before *and* after each test to force a
+clean re-arm.
+
+**Verified:** full test suite (977 passed, 21 skipped, no regressions), plus
+a manual repro script simulating CLI startup → pre-launch warning (visible
+on console, as intended) → `detach_console_handler()` → post-launch warning
+(silent on console, present in `hatchery.log`) — matching the exact failure
+mode from the screenshots.

--- a/src/seekr_hatchery/kubectl_proxy.py
+++ b/src/seekr_hatchery/kubectl_proxy.py
@@ -468,6 +468,18 @@ class _RBACProxyHandler(http.server.BaseHTTPRequestHandler):
 class _ThreadingHTTPServer(socketserver.ThreadingMixIn, http.server.HTTPServer):
     daemon_threads = True
 
+    def handle_error(self, request: Any, client_address: Any) -> None:
+        """Log request-handling exceptions instead of printing to stderr.
+
+        The ``socketserver`` default prints a traceback straight to
+        ``sys.stderr`` via ``print``/``traceback.print_exc()``, bypassing the
+        logging module entirely — a raw write from this background thread
+        corrupts the agent's TUI, which shares the same terminal. TLS
+        handshake failures against the TLS-terminating RBAC proxy are the
+        most common trigger.
+        """
+        logger.warning("Error handling request from %s", client_address, exc_info=True)
+
 
 # ── TLS cert generation ───────────────────────────────────────────────────────
 

--- a/src/seekr_hatchery/logging_.py
+++ b/src/seekr_hatchery/logging_.py
@@ -25,6 +25,14 @@ import seekr_hatchery.ui as ui
 # Parent logger for the whole package.
 _pkg_logger = logging.getLogger("seekr_hatchery")
 
+# ``logging.captureWarnings(True)`` (enabled in configure_logging) routes
+# ``warnings.warn()`` through this logger instead of straight to stderr via
+# ``warnings.showwarning``.  Managed alongside _pkg_logger so warnings get
+# the same file/console handling (and the same detach-before-launch safety).
+_warnings_logger = logging.getLogger("py.warnings")
+
+_MANAGED_LOGGERS = (_pkg_logger, _warnings_logger)
+
 # Global log file: always-on rotating file handler at ~/.hatchery/hatchery.log.
 _LOG_MAX_BYTES = 5 * 1024 * 1024  # 5 MB
 _LOG_BACKUP_COUNT = 3
@@ -76,6 +84,12 @@ def configure_logging(level: str) -> None:
     always captures at least INFO, so debuggable signal is on disk even when the
     console is quiet.  When ``level="DEBUG"``, both handlers get DEBUG.
 
+    Also enables ``logging.captureWarnings`` so ``warnings.warn()`` calls
+    (e.g. urllib3's ``InsecureRequestWarning``) are routed through these same
+    handlers instead of being printed straight to stderr — a raw stderr write
+    from a background thread (like the API proxy) would otherwise corrupt the
+    agent's TUI, which shares the same terminal.
+
     Call :func:`detach_console_handler` before launching the agent sandbox —
     console output after that point corrupts the agent's TUI.
 
@@ -92,7 +106,8 @@ def configure_logging(level: str) -> None:
     console = logging.StreamHandler(sys.stderr)
     console.setLevel(log_level)
     console.setFormatter(ui.ColorFormatter(_LOG_FMT, datefmt=_LOG_DATEFMT))
-    _pkg_logger.addHandler(console)
+    for logger in _MANAGED_LOGGERS:
+        logger.addHandler(console)
 
     # File handler — always on, rotating.
     try:
@@ -102,23 +117,29 @@ def configure_logging(level: str) -> None:
         )
         file_handler.setLevel(file_level)
         file_handler.setFormatter(_HatcheryFormatter(_LOG_FMT, datefmt=_LOG_DATEFMT))
-        _pkg_logger.addHandler(file_handler)
+        for logger in _MANAGED_LOGGERS:
+            logger.addHandler(file_handler)
     except OSError:
         # Non-fatal: console logging still works.
         pass
 
-    _pkg_logger.setLevel(min(log_level, file_level))
+    for logger in _MANAGED_LOGGERS:
+        logger.setLevel(min(log_level, file_level))
+
+    logging.captureWarnings(True)
 
 
 def detach_console_handler() -> None:
-    """Remove all console (StreamHandler) handlers from the package logger.
+    """Remove all console (StreamHandler) handlers from the managed loggers.
 
     Call this right before launching the agent sandbox so logging output
-    doesn't corrupt the agent's TUI.  File handlers are untouched.
+    (including captured ``warnings.warn()`` calls) doesn't corrupt the
+    agent's TUI.  File handlers are untouched.
     """
-    for h in list(_pkg_logger.handlers):
-        if isinstance(h, logging.StreamHandler) and not isinstance(h, logging.handlers.RotatingFileHandler):
-            _pkg_logger.removeHandler(h)
+    for logger in _MANAGED_LOGGERS:
+        for h in list(logger.handlers):
+            if isinstance(h, logging.StreamHandler) and not isinstance(h, logging.handlers.RotatingFileHandler):
+                logger.removeHandler(h)
 
 
 def get_file_handlers() -> list[logging.handlers.RotatingFileHandler]:
@@ -147,9 +168,11 @@ def task_log(session_dir: Path, level: int = logging.INFO) -> Generator[None, No
     )
     task_fh.setLevel(level)
     task_fh.setFormatter(_HatcheryFormatter(_LOG_FMT, datefmt=_LOG_DATEFMT))
-    _pkg_logger.addHandler(task_fh)
+    for logger in _MANAGED_LOGGERS:
+        logger.addHandler(task_fh)
     try:
         yield
     finally:
-        _pkg_logger.removeHandler(task_fh)
+        for logger in _MANAGED_LOGGERS:
+            logger.removeHandler(task_fh)
         task_fh.close()

--- a/src/seekr_hatchery/proxy.py
+++ b/src/seekr_hatchery/proxy.py
@@ -324,6 +324,16 @@ class _ThreadingHTTPServer(socketserver.ThreadingMixIn, http.server.HTTPServer):
 
     daemon_threads = True
 
+    def handle_error(self, request: Any, client_address: Any) -> None:
+        """Log request-handling exceptions instead of printing to stderr.
+
+        The ``socketserver`` default prints a traceback straight to
+        ``sys.stderr`` via ``print``/``traceback.print_exc()``, bypassing the
+        logging module entirely — a raw write from this background thread
+        corrupts the agent's TUI, which shares the same terminal.
+        """
+        logger.warning("Error handling request from %s", client_address, exc_info=True)
+
 
 class APIServer:
     """Public handle for a running API proxy server.

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -2,6 +2,7 @@
 
 import logging
 import logging.handlers
+import warnings
 from pathlib import Path
 
 import pytest
@@ -33,6 +34,32 @@ def hatchery_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     d = tmp_path / ".hatchery"
     monkeypatch.setattr(constants, "HATCHERY_DIR", d)
     return d
+
+
+@pytest.fixture()
+def clean_warnings_logger():
+    """Reset the py.warnings logger and captureWarnings state before/after each test.
+
+    pytest wraps every test in its own ``warnings.catch_warnings()``, which
+    restores ``warnings.showwarning`` to the stdlib default at each test's
+    teardown. ``logging.captureWarnings()`` only re-arms ``showwarning`` when
+    its internal "already capturing" flag is unset, so once any earlier test
+    in the session has called it, later calls silently no-op and
+    ``warnings.warn()`` falls through to the real default instead of
+    logging. Force that flag off before *and* after this test so
+    ``configure_logging()``'s ``captureWarnings(True)`` call actually takes
+    effect here, regardless of what ran before. This reset dance is purely a
+    test artifact — in real usage configure_logging() runs once per process.
+    """
+    logging.captureWarnings(False)
+    logger = logging.getLogger("py.warnings")
+    saved_handlers = logger.handlers[:]
+    saved_level = logger.level
+    logger.handlers = []
+    yield logger
+    logger.handlers = saved_handlers
+    logger.setLevel(saved_level)
+    logging.captureWarnings(False)
 
 
 # ---------------------------------------------------------------------------
@@ -250,3 +277,48 @@ class TestDetachConsoleHandler:
         captured = capsys.readouterr()
         assert "after-detach" not in captured.err
         assert "after-detach" in (hatchery_dir / "hatchery.log").read_text()
+
+
+# ---------------------------------------------------------------------------
+# warnings.warn() capture (e.g. urllib3's InsecureRequestWarning)
+# ---------------------------------------------------------------------------
+
+
+class TestWarningsCapture:
+    """warnings.warn() is routed through logging instead of straight to stderr.
+
+    A raw ``warnings.warn()`` write bypasses the ``seekr_hatchery`` logger
+    entirely, so without ``logging.captureWarnings``, it would land on
+    stderr even after ``detach_console_handler()`` — corrupting the agent's
+    TUI, which shares the same terminal as the host process.
+    """
+
+    def test_warnings_go_to_file(self, clean_logger, clean_warnings_logger, hatchery_dir):
+        """warnings.warn() is captured by logging and lands in the log file.
+
+        Before detach_console_handler, it also reaches stderr — same as any
+        other WARNING-level log line at this point (pre-launch diagnostics
+        are meant to be visible). The critical property is checked by
+        test_warnings_suppressed_after_detach below: once detached, it must
+        not reach stderr, since that's the terminal shared with the agent.
+        """
+        logging_.configure_logging("INFO")
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("always")
+            warnings.warn("test-warning-message", UserWarning)
+
+        assert "test-warning-message" in (hatchery_dir / "hatchery.log").read_text()
+
+    def test_warnings_suppressed_after_detach(self, clean_logger, clean_warnings_logger, hatchery_dir, capsys):
+        """After detach_console_handler, warnings still reach the file but not stderr."""
+        logging_.configure_logging("INFO")
+        logging_.detach_console_handler()
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("always")
+            warnings.warn("post-detach-warning", UserWarning)
+
+        captured = capsys.readouterr()
+        assert "post-detach-warning" not in captured.err
+        assert "post-detach-warning" in (hatchery_dir / "hatchery.log").read_text()


### PR DESCRIPTION
Python's warnings module (e.g. urllib3's InsecureRequestWarning, raised because truststore.SSLContext reports verify_mode=CERT_NONE even though it verifies against the OS trust store itself) writes straight to stderr, bypassing the logging_.py pipeline entirely -- including detach_console_handler(), which exists specifically to keep console output from corrupting the agent's TUI once it shares the terminal.

Route warnings through logging via logging.captureWarnings(True), and manage a py.warnings logger alongside the seekr_hatchery logger so it gets the same console/file handling and detach behavior.

Also close a second instance of the same bug class: neither proxy's _ThreadingHTTPServer overrode handle_error(), so socketserver's default also printed tracebacks straight to stderr on request-handling exceptions (e.g. TLS handshake failures).